### PR TITLE
Fixed 'va_copy' warning VS19

### DIFF
--- a/metamod/comp_dep.h
+++ b/metamod/comp_dep.h
@@ -75,8 +75,10 @@
 #endif
 
 #if defined (_WIN32) && defined (_MSC_VER)
-	// On x86 va_list is just a pointer.
-	#define va_copy(dst,src) ((dst)=(src))
+	#ifndef va_copy
+		// On x86 va_list is just a pointer.
+		#define va_copy(dst,src) ((dst)=(src))
+	#endif
 #else
 	// Some systems that do not supply va_copy have __va_copy instead, since 
 	// that was the name used in the draft proposal.


### PR DESCRIPTION
-added macro redefinition