### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-multilib
+      - name: Build metamod (debug)
+        run: make -j4 -C metamod CC="gcc -m32"
+      - name: Build metamod (optimized)
+        run: make -j4 -C metamod CC="gcc -m32" OPT=opt
+      - name: Build trace_plugin (optimized)
+        run: make -j4 -C trace_plugin CC="gcc -m32" OPT=opt
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-binaries
+          path: |
+            metamod/opt.linux_i386/metamod.so
+            trace_plugin/opt.linux_i386/trace_mm.so
+
+  build-linux-bionic:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build in Ubuntu 18.04 i386 container
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
+            lpenz/ubuntu-bionic-i386 \
+            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && \
+              make -j4 -C metamod OPT=opt && \
+              make -j4 -C trace_plugin OPT=opt"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-bionic-binaries
+          path: |
+            metamod/opt.linux_i386/metamod.so
+            trace_plugin/opt.linux_i386/trace_mm.so
+
+  build-windows:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install packages
+        run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
+      - name: Build metamod (optimized)
+        run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+      - name: Build trace_plugin (optimized)
+        run: make -j4 -C trace_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-binaries
+          path: |
+            metamod/opt.win32/metamod.dll
+            trace_plugin/opt.win32/trace_mm.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  package:
+    needs: [build]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: snapshot

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,110 @@
+name: Package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      create_release:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  package-linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download Linux binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-binaries
+          path: staging
+      - name: Prepare release directory
+        run: |
+          mkdir -p addons/metamod/dlls
+          cp staging/metamod/opt.linux_i386/metamod.so addons/metamod/dlls/
+          cp staging/trace_plugin/opt.linux_i386/trace_mm.so addons/metamod/dlls/
+      - name: Create release archive
+        run: tar c addons | xz > metamod-p-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: metamod-p-${{ inputs.version }}-linux_ubuntu2404
+          path: metamod-p-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+
+  package-linux-bionic:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download Linux Bionic binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-bionic-binaries
+          path: staging
+      - name: Prepare release directory
+        run: |
+          mkdir -p addons/metamod/dlls
+          cp staging/metamod/opt.linux_i386/metamod.so addons/metamod/dlls/
+          cp staging/trace_plugin/opt.linux_i386/trace_mm.so addons/metamod/dlls/
+      - name: Create release archive
+        run: tar c addons | xz > metamod-p-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: metamod-p-${{ inputs.version }}-linux_ubuntu1804
+          path: metamod-p-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+
+  package-windows:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download Windows binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-binaries
+          path: staging
+      - name: Prepare release directory
+        run: |
+          mkdir -p addons/metamod/dlls
+          cp staging/metamod/opt.win32/metamod.dll addons/metamod/dlls/
+          cp staging/trace_plugin/opt.win32/trace_mm.dll addons/metamod/dlls/
+      - name: Create release archive
+        run: tar c addons | xz > metamod-p-${{ inputs.version }}-win32.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: metamod-p-${{ inputs.version }}-win32
+          path: metamod-p-${{ inputs.version }}-win32.tar.xz
+
+  create-release:
+    if: ${{ inputs.create_release }}
+    needs: [package-linux, package-linux-bionic, package-windows]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Download Linux archive
+        uses: actions/download-artifact@v8
+        with:
+          name: metamod-p-${{ inputs.version }}-linux_ubuntu2404
+      - name: Download Linux Bionic archive
+        uses: actions/download-artifact@v8
+        with:
+          name: metamod-p-${{ inputs.version }}-linux_ubuntu1804
+      - name: Download Windows archive
+        uses: actions/download-artifact@v8
+        with:
+          name: metamod-p-${{ inputs.version }}-win32
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            metamod-p-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+            metamod-p-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+            metamod-p-${{ inputs.version }}-win32.tar.xz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      version: ${{ steps.parse.outputs.VERSION }}
+    steps:
+      - name: Parse version from tag
+        id: parse
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+p[0-9]+ ]]; then
+            echo "VERSION=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Invalid tag format '$TAG', expected v<major>.<minor>p<patch> (e.g. v1.21p38)"
+            exit 1
+          fi
+
+  build:
+    needs: validate-tag
+    uses: ./.github/workflows/build.yml
+
+  package:
+    needs: [validate-tag, build]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.version }}
+      create_release: true
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

- Add CI pipeline following the same workflow structure as [jk_botti](https://github.com/Bots-United/jk_botti)
- Builds metamod and trace_plugin for Linux (ubuntu-24.04), Linux legacy (ubuntu-18.04 i386 container), and Win32 (mingw cross-compile)
- Packages release archives per platform
- Tag-triggered release workflow for `v*` tags (e.g. `v1.21p39`)

## Workflow files

| File | Purpose |
|------|---------|
| `ci.yml` | Main entry point — triggers on push to master and PRs |
| `build.yml` | Reusable build job for all three platforms |
| `package.yml` | Creates `addons/metamod/dlls/` release archives |
| `release.yml` | Tag-triggered build + release creation |

## Test plan

- [ ] CI runs on this PR and builds succeed
- [ ] Verify artifact uploads contain the expected binaries

Closes #51