### PR TITLE
Fix memory leak in MConfig::load() on config reload

### DIFF
--- a/metamod/conf_meta.cpp
+++ b/metamod/conf_meta.cpp
@@ -196,6 +196,7 @@ mBOOL DLLINTERNAL MConfig::load(const char *fn) {
 			continue;
 		}
 	}
+	free(filename);
 	filename=strdup(loadfile);
 	fclose(fp);
 	return(mTRUE);


### PR DESCRIPTION
## Summary
- Free previous `filename` before `strdup` assignment in `MConfig::load()` to prevent memory leak on repeated config loads.

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit ac15ef9).

Fixes #42