### PR TITLE
Fix engineinfo phdr_dladdr/phdr_r_debug logic and init

### DIFF
--- a/metamod/engineinfo.cpp
+++ b/metamod/engineinfo.cpp
@@ -293,7 +293,7 @@ int DLLINTERNAL EngineInfo::phdr_dladdr( void* _pMem )
 int DLLINTERNAL EngineInfo::phdr_r_debug( void )
 {
 	ElfW(Dyn)* pDyn; 
-	struct r_debug* pr_debug;
+	struct r_debug* pr_debug = NULL;
 	struct link_map* pMap;
 
 
@@ -370,7 +370,7 @@ int DLLINTERNAL EngineInfo::initialise( enginefuncs_t* _pFuncs )
 	}
 
 	// If we have a refererence pointer we try to use it first.
-	if ( 0 != phdr_dladdr(_pFuncs) ) {
+	else if ( 0 != phdr_dladdr(_pFuncs) ) {
 		ret = phdr_r_debug();
 	}
 


### PR DESCRIPTION
## Summary
- Change independent if-statements for `phdr_dladdr`/`phdr_r_debug` to else-if chain so `phdr_r_debug` only runs as fallback.
- Initialize `pr_debug` to NULL in `phdr_r_debug()` to prevent use of uninitialized variable.

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit 336dfb3).

Fixes #44