### PR TITLE
Fix null crash in meta_QueryClientCvarValue

### DIFF
--- a/metamod/reg_support.cpp
+++ b/metamod/reg_support.cpp
@@ -223,6 +223,7 @@ int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize) {
 // Intercept and record queries
 void DLLHIDDEN meta_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
 	g_Players.set_player_cvar_query(player, cvarName);
-	
-	(*g_engfuncs.pfnQueryClientCvarValue)(player, cvarName);
+
+	if(g_engfuncs.pfnQueryClientCvarValue)
+		(*g_engfuncs.pfnQueryClientCvarValue)(player, cvarName);
 }


### PR DESCRIPTION
## Summary
- Add null check for `pfnQueryClientCvarValue` function pointer before calling it, preventing crash on engine versions that don't provide this function.

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit 336dfb3).

Fixes #45