### PR TITLE
Add defensive null check for dllapi_table after game DLL load

### DIFF
--- a/metamod/metamod.cpp
+++ b/metamod/metamod.cpp
@@ -453,6 +453,11 @@ mBOOL DLLINTERNAL meta_load_gamedll(void) {
 		RETURN_ERRNO(mFALSE, ME_DLMISSING);
 	}
 
+	if(!GameDLL.funcs.dllapi_table) {
+		META_WARNING("dll: GetEntityAPI function pointer is null in game DLL '%s'", GameDLL.name);
+		RETURN_ERRNO(mFALSE, ME_DLMISSING);
+	}
+
 	META_LOG("Game DLL for '%s' loaded successfully", GameDLL.desc);
 	return(mTRUE);
 }


### PR DESCRIPTION
## Summary
- Add null check for `GameDLL.funcs.dllapi_table` after `GET_FUNC_TABLE_FROM_GAME` calls, preventing potential null pointer dereference if `GetEntityAPI` returns success but leaves the table empty.
- Low priority defensive check — shouldn't happen with well-behaved game DLLs.

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit 911fa1c).

Fixes #48