### PR TITLE
Fix DoD warning spam from message ID reuse

### DIFF
--- a/metamod/engine_api.cpp
+++ b/metamod/engine_api.cpp
@@ -468,6 +468,11 @@ static int mm_RegUserMsg(const char *pszName, int iSize) {
 		if(FStrEq(pszName, nmsg->name))
 			// This name/msgid pair was already registered.
 			META_DEBUG(3, ("user message registered again: name=%s, msgid=%d", pszName, imsgid));
+		else if(!nmsg->name || !nmsg->name[0]) {
+			// Previously registered with empty name, update with actual name.
+			nmsg->name = strdup(pszName);
+			META_DEBUG(3, ("user message name updated: msgid=%d, name=%s", imsgid, pszName));
+		}
 		else
 			// This msgid was previously used by a different message name.
 			META_WARNING("user message id reused: msgid=%d, oldname=%s, newname=%s", imsgid, nmsg->name, pszName);

--- a/metamod/mreg.cpp
+++ b/metamod/mreg.cpp
@@ -493,7 +493,7 @@ MRegMsg * DLLINTERNAL MRegMsgList::add(const char *addname, int addmsgid, int ad
 MRegMsg * DLLINTERNAL MRegMsgList::find(const char *findname) {
 	int i;
 	for(i=0; i < endlist; i++) {
-		if(!mm_strcmp(mlist[i].name, findname))
+		if(mlist[i].name && !mm_strcmp(mlist[i].name, findname))
 			return(&mlist[i]);
 	}
 	RETURN_ERRNO(NULL, ME_NOTFOUND);
@@ -521,7 +521,7 @@ void DLLINTERNAL MRegMsgList::show(void) {
 			sizeof(bname)-1, "Game registered user msgs:", "msgid", "size");
 	for(i=0; i < endlist; i++) {
 		imsg = &mlist[i];
-		STRNCPY(bname, imsg->name, sizeof(bname));
+		STRNCPY(bname, imsg->name ? imsg->name : "(null)", sizeof(bname));
 		META_CONS("   %-*s   %3d    %3d", 
 				sizeof(bname)-1, bname,
 				imsg->msgid,


### PR DESCRIPTION
## Summary
- In `mm_RegUserMsg`: when a previously registered msgid has an empty/null name, update it with the actual name instead of logging a spurious "user message id reused" warning. Some mods (notably Day of Defeat) register message IDs before assigning names.
- In `MRegMsgList::find()` and `MRegMsgList::show()`: add null checks for `mlist[i].name` to prevent null pointer dereference.

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit 5104142).

Fixes #49