### PR TITLE
Fix engineinfo initialise() returning 0 instead of ret

### DIFF
--- a/metamod/engineinfo.cpp
+++ b/metamod/engineinfo.cpp
@@ -380,11 +380,11 @@ int DLLINTERNAL EngineInfo::initialise( enginefuncs_t* _pFuncs )
 		META_DEV( "Unable to determine engine code address range!" );
 	}
 	else {
-		META_DEV( "Set engine code range: start address = %p, end address = %p", 
+		META_DEV( "Set engine code range: start address = %p, end address = %p",
 			 m_codeStart, m_codeEnd );
 	}
 
-	return 0;
+	return ret;
 }
 
 


### PR DESCRIPTION
## Summary
- `EngineInfo::initialise()` returned hardcoded `0` instead of `ret`, discarding the actual result from `phdr_dladdr`/`phdr_r_debug` (or `nthdr_module_name`/`vac_pe_approx` on Win32).

Originally found and fixed by [@APGRoboCop](https://github.com/APGRoboCop) in the [APG fork](https://github.com/APGRoboCop/metamod-p) (commit 336dfb3).

Fixes #43