### PR TITLE
Add GETPLAYERAUTHID define to enginecallback.h

### DIFF
--- a/hlsdk/dlls/enginecallback.h
+++ b/hlsdk/dlls/enginecallback.h
@@ -72,6 +72,7 @@ extern enginefuncs_t g_engfuncs;
 #define RANDOM_LONG		(*g_engfuncs.pfnRandomLong)
 #define RANDOM_FLOAT	(*g_engfuncs.pfnRandomFloat)
 #define GETPLAYERWONID	(*g_engfuncs.pfnGetPlayerWONId)
+#define GETPLAYERAUTHID	(*g_engfuncs.pfnGetPlayerAuthId)
 
 inline void MESSAGE_BEGIN( int msg_dest, int msg_type, const float *pOrigin = NULL, edict_t *ed = NULL ) {
 	(*g_engfuncs.pfnMessageBegin)(msg_dest, msg_type, pOrigin, ed);


### PR DESCRIPTION
## Summary
- Add missing `#define GETPLAYERAUTHID (*g_engfuncs.pfnGetPlayerAuthId)` convenience macro to `hlsdk/dlls/enginecallback.h`, alongside the existing `GETPLAYERWONID`.
- The function pointer `pfnGetPlayerAuthId` already exists in `eiface.h` but lacked a matching macro in `enginecallback.h`.

Fixes #27