### PR TITLE
Replace -mincoming-stack-boundary=2 with per-function FORCE_STACK_ALIGN

### DIFF
--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -161,7 +161,7 @@ CCO += -fno-strict-aliasing -fno-strict-overflow
 ifeq "$(TARGETTYPE)" "amd64"
 	CCOPT_ARCH =
 else
-	CCOPT_ARCH = -march=i686 $(MCPU)=generic -msse2 -mincoming-stack-boundary=2
+	CCOPT_ARCH = -march=i686 $(MCPU)=generic -msse2
 endif
 
 # debugging; halt on warnings

--- a/metamod/comp_dep.h
+++ b/metamod/comp_dep.h
@@ -88,6 +88,14 @@
 	#endif
 #endif
 
+// On 32-bit x86, the HL engine may call functions with only 4-byte stack
+// alignment. Apply this to entry points called by engine/gamedll/plugins.
+#if defined(__GNUC__) && defined(__i386__)
+	#define FORCE_STACK_ALIGN __attribute__((force_align_arg_pointer))
+#else
+	#define FORCE_STACK_ALIGN
+#endif
+
 // Manual branch optimization for GCC 3.0.0 and newer
 #if !defined(__GNUC__) || __GNUC__ < 3
 	#define likely(x) (x)

--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -76,108 +76,108 @@
 
 
 // From SDK dlls/game.cpp:
-static void mm_GameDLLInit(void) {
+static FORCE_STACK_ALIGN void mm_GameDLLInit(void) {
 	META_DLLAPI_HANDLE_void(FN_GAMEINIT, pfnGameInit, void, (VOID_ARG));
 	RETURN_API_void();
 }
 
 // From SDK dlls/cbase.cpp:
-static int mm_DispatchSpawn(edict_t *pent) {
+static FORCE_STACK_ALIGN int mm_DispatchSpawn(edict_t *pent) {
 	// 0==Success, -1==Failure ?
 	META_DLLAPI_HANDLE(int, 0, FN_DISPATCHSPAWN, pfnSpawn, p, (pent));
 	RETURN_API(int);
 }
-static void mm_DispatchThink(edict_t *pent) {
+static FORCE_STACK_ALIGN void mm_DispatchThink(edict_t *pent) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHTHINK, pfnThink, p, (pent));
 	RETURN_API_void();
 }
-static void mm_DispatchUse(edict_t *pentUsed, edict_t *pentOther) {
+static FORCE_STACK_ALIGN void mm_DispatchUse(edict_t *pentUsed, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHUSE, pfnUse, 2p, (pentUsed, pentOther));
 	RETURN_API_void();
 }
-static void mm_DispatchTouch(edict_t *pentTouched, edict_t *pentOther) {
+static FORCE_STACK_ALIGN void mm_DispatchTouch(edict_t *pentTouched, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHTOUCH, pfnTouch, 2p, (pentTouched, pentOther));
 	RETURN_API_void();
 }
-static void mm_DispatchBlocked(edict_t *pentBlocked, edict_t *pentOther) {
+static FORCE_STACK_ALIGN void mm_DispatchBlocked(edict_t *pentBlocked, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHBLOCKED, pfnBlocked, 2p, (pentBlocked, pentOther));
 	RETURN_API_void();
 }
-static void mm_DispatchKeyValue(edict_t *pentKeyvalue, KeyValueData *pkvd) {
+static FORCE_STACK_ALIGN void mm_DispatchKeyValue(edict_t *pentKeyvalue, KeyValueData *pkvd) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHKEYVALUE, pfnKeyValue, 2p, (pentKeyvalue, pkvd));
 	RETURN_API_void();
 }
-static void mm_DispatchSave(edict_t *pent, SAVERESTOREDATA *pSaveData) {
+static FORCE_STACK_ALIGN void mm_DispatchSave(edict_t *pent, SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHSAVE, pfnSave, 2p, (pent, pSaveData));
 	RETURN_API_void();
 }
-static int mm_DispatchRestore(edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity) {
+static FORCE_STACK_ALIGN int mm_DispatchRestore(edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity) {
 	// 0==Success, -1==Failure ?
 	META_DLLAPI_HANDLE(int, 0, FN_DISPATCHRESTORE, pfnRestore, 2pi, (pent, pSaveData, globalEntity));
 	RETURN_API(int);
 }
-static void mm_DispatchObjectCollisionBox(edict_t *pent) {
+static FORCE_STACK_ALIGN void mm_DispatchObjectCollisionBox(edict_t *pent) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHOBJECTCOLLISIONBOX, pfnSetAbsBox, p, (pent));
 	RETURN_API_void();
 }
-static void mm_SaveWriteFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
+static FORCE_STACK_ALIGN void mm_SaveWriteFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
 	META_DLLAPI_HANDLE_void(FN_SAVEWRITEFIELDS, pfnSaveWriteFields, 4pi, (pSaveData, pname, pBaseData, pFields, fieldCount));
 	RETURN_API_void();
 }
-static void mm_SaveReadFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
+static FORCE_STACK_ALIGN void mm_SaveReadFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
 	META_DLLAPI_HANDLE_void(FN_SAVEREADFIELDS, pfnSaveReadFields, 4pi, (pSaveData, pname, pBaseData, pFields, fieldCount));
 	RETURN_API_void();
 }
 
 // From SDK dlls/world.cpp:
-static void mm_SaveGlobalState(SAVERESTOREDATA *pSaveData) {
+static FORCE_STACK_ALIGN void mm_SaveGlobalState(SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_SAVEGLOBALSTATE, pfnSaveGlobalState, p, (pSaveData));
 	RETURN_API_void();
 }
-static void mm_RestoreGlobalState(SAVERESTOREDATA *pSaveData) {
+static FORCE_STACK_ALIGN void mm_RestoreGlobalState(SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_RESTOREGLOBALSTATE, pfnRestoreGlobalState, p, (pSaveData));
 	RETURN_API_void();
 }
-static void mm_ResetGlobalState(void) {
+static FORCE_STACK_ALIGN void mm_ResetGlobalState(void) {
 	META_DLLAPI_HANDLE_void(FN_RESETGLOBALSTATE, pfnResetGlobalState, void, (VOID_ARG));
 	RETURN_API_void();
 }
 
 // From SDK dlls/client.cpp:
-static qboolean mm_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]) {
+static FORCE_STACK_ALIGN qboolean mm_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]) {
 	g_Players.clear_player_cvar_query(pEntity);
 	META_DLLAPI_HANDLE(qboolean, TRUE, FN_CLIENTCONNECT, pfnClientConnect, 4p, (pEntity, pszName, pszAddress, szRejectReason));
 	RETURN_API(qboolean);
 }
-static void mm_ClientDisconnect(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_ClientDisconnect(edict_t *pEntity) {
 	g_Players.clear_player_cvar_query(pEntity);
 	META_DLLAPI_HANDLE_void(FN_CLIENTDISCONNECT, pfnClientDisconnect, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_ClientKill(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_ClientKill(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTKILL, pfnClientKill, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_ClientPutInServer(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_ClientPutInServer(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTPUTINSERVER, pfnClientPutInServer, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_ClientCommand(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_ClientCommand(edict_t *pEntity) {
 	if(Config->clientmeta && strmatch(CMD_ARGV(0), "meta")) {
 		client_meta(pEntity);
 	}
 	META_DLLAPI_HANDLE_void(FN_CLIENTCOMMAND, pfnClientCommand, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_ClientUserInfoChanged(edict_t *pEntity, char *infobuffer) {
+static FORCE_STACK_ALIGN void mm_ClientUserInfoChanged(edict_t *pEntity, char *infobuffer) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTUSERINFOCHANGED, pfnClientUserInfoChanged, 2p, (pEntity, infobuffer));
 	RETURN_API_void();
 }
-static void mm_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax) {
+static FORCE_STACK_ALIGN void mm_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax) {
 	META_DLLAPI_HANDLE_void(FN_SERVERACTIVATE, pfnServerActivate, p2i, (pEdictList, edictCount, clientMax));
 	RETURN_API_void();
 }
-static void mm_ServerDeactivate(void) {
+static FORCE_STACK_ALIGN void mm_ServerDeactivate(void) {
 	META_DLLAPI_HANDLE_void(FN_SERVERDEACTIVATE, pfnServerDeactivate, void, (VOID_ARG));
 	// Update loaded plugins.  Look for new plugins in inifile, as well as
 	// any plugins waiting for a changelevel to load.  
@@ -199,117 +199,117 @@ static void mm_ServerDeactivate(void) {
 	requestid_counter = 0;
 	RETURN_API_void();
 }
-static void mm_PlayerPreThink(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_PlayerPreThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERPRETHINK, pfnPlayerPreThink, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_PlayerPostThink(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_PlayerPostThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERPOSTTHINK, pfnPlayerPostThink, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_StartFrame(void) {
+static FORCE_STACK_ALIGN void mm_StartFrame(void) {
 	meta_debug_value = (int)meta_debug.value;
 
 	META_DLLAPI_HANDLE_void(FN_STARTFRAME, pfnStartFrame, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static void mm_ParmsNewLevel(void) {
+static FORCE_STACK_ALIGN void mm_ParmsNewLevel(void) {
 	META_DLLAPI_HANDLE_void(FN_PARMSNEWLEVEL, pfnParmsNewLevel, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static void mm_ParmsChangeLevel(void) {
+static FORCE_STACK_ALIGN void mm_ParmsChangeLevel(void) {
 	META_DLLAPI_HANDLE_void(FN_PARMSCHANGELEVEL, pfnParmsChangeLevel, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static const char *mm_GetGameDescription(void) {
+static FORCE_STACK_ALIGN const char *mm_GetGameDescription(void) {
 	META_DLLAPI_HANDLE(const char *, NULL, FN_GETGAMEDESCRIPTION, pfnGetGameDescription, void, (VOID_ARG));
 	RETURN_API(const char *);
 }
-static void mm_PlayerCustomization(edict_t *pEntity, customization_t *pCust) {
+static FORCE_STACK_ALIGN void mm_PlayerCustomization(edict_t *pEntity, customization_t *pCust) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERCUSTOMIZATION, pfnPlayerCustomization, 2p, (pEntity, pCust));
 	RETURN_API_void();
 }
-static void mm_SpectatorConnect(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_SpectatorConnect(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORCONNECT, pfnSpectatorConnect, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_SpectatorDisconnect(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_SpectatorDisconnect(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORDISCONNECT, pfnSpectatorDisconnect, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_SpectatorThink(edict_t *pEntity) {
+static FORCE_STACK_ALIGN void mm_SpectatorThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORTHINK, pfnSpectatorThink, p, (pEntity));
 	RETURN_API_void();
 }
-static void mm_Sys_Error(const char *error_string) {
+static FORCE_STACK_ALIGN void mm_Sys_Error(const char *error_string) {
 	META_DLLAPI_HANDLE_void(FN_SYS_ERROR, pfnSys_Error, p, (error_string));
 	RETURN_API_void();
 }
 
 // From SDK pm_shared/pm_shared.c:
-static void mm_PM_Move (struct playermove_s *ppmove, int server) {
+static FORCE_STACK_ALIGN void mm_PM_Move (struct playermove_s *ppmove, int server) {
 	META_DLLAPI_HANDLE_void(FN_PM_MOVE, pfnPM_Move, pi, (ppmove, server));
 	RETURN_API_void();
 }
-static void mm_PM_Init(struct playermove_s *ppmove) {
+static FORCE_STACK_ALIGN void mm_PM_Init(struct playermove_s *ppmove) {
 	META_DLLAPI_HANDLE_void(FN_PM_INIT, pfnPM_Init, p, (ppmove));
 	RETURN_API_void();
 }
-static char mm_PM_FindTextureType(char *name) {
+static FORCE_STACK_ALIGN char mm_PM_FindTextureType(char *name) {
 	META_DLLAPI_HANDLE(char, '\0', FN_PM_FINDTEXTURETYPE, pfnPM_FindTextureType, p, (name));
 	RETURN_API(char);
 }
 
 // From SDK dlls/client.cpp:
-static void mm_SetupVisibility(edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas) {
+static FORCE_STACK_ALIGN void mm_SetupVisibility(edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas) {
 	META_DLLAPI_HANDLE_void(FN_SETUPVISIBILITY, pfnSetupVisibility, 4p, (pViewEntity, pClient, pvs, pas));
 	RETURN_API_void();
 }
-static void mm_UpdateClientData (const struct edict_s *ent, int sendweapons, struct clientdata_s *cd) {
+static FORCE_STACK_ALIGN void mm_UpdateClientData (const struct edict_s *ent, int sendweapons, struct clientdata_s *cd) {
 	META_DLLAPI_HANDLE_void(FN_UPDATECLIENTDATA, pfnUpdateClientData, pip, (ent, sendweapons, cd));
 	RETURN_API_void();
 }
-static int mm_AddToFullPack(struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet) {
+static FORCE_STACK_ALIGN int mm_AddToFullPack(struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet) {
 	META_DLLAPI_HANDLE(int, 0, FN_ADDTOFULLPACK, pfnAddToFullPack, pi2p2ip, (state, e, ent, host, hostflags, player, pSet));
 	RETURN_API(int);
 }
-static void mm_CreateBaseline(int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs) {
+static FORCE_STACK_ALIGN void mm_CreateBaseline(int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs) {
 	META_DLLAPI_HANDLE_void(FN_CREATEBASELINE, pfnCreateBaseline, 2i2pi2p, (player, eindex, baseline, entity, playermodelindex, (float*)player_mins, (float*)player_maxs));
 	RETURN_API_void();
 }
-static void mm_RegisterEncoders(void) {
+static FORCE_STACK_ALIGN void mm_RegisterEncoders(void) {
 	META_DLLAPI_HANDLE_void(FN_REGISTERENCODERS, pfnRegisterEncoders, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static int mm_GetWeaponData(struct edict_s *player, struct weapon_data_s *info) {
+static FORCE_STACK_ALIGN int mm_GetWeaponData(struct edict_s *player, struct weapon_data_s *info) {
 	META_DLLAPI_HANDLE(int, 0, FN_GETWEAPONDATA, pfnGetWeaponData, 2p, (player, info));
 	RETURN_API(int);
 }
-static void mm_CmdStart(const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed) {
+static FORCE_STACK_ALIGN void mm_CmdStart(const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed) {
 	META_DLLAPI_HANDLE_void(FN_CMDSTART, pfnCmdStart, 2pui, (player, cmd, random_seed));
 	RETURN_API_void();
 }
-static void mm_CmdEnd (const edict_t *player) {
+static FORCE_STACK_ALIGN void mm_CmdEnd (const edict_t *player) {
 	META_DLLAPI_HANDLE_void(FN_CMDEND, pfnCmdEnd, p, (player));
 	RETURN_API_void();
 }
-static int mm_ConnectionlessPacket(const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size) {
+static FORCE_STACK_ALIGN int mm_ConnectionlessPacket(const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size) {
 	META_DLLAPI_HANDLE(int, 0, FN_CONNECTIONLESSPACKET, pfnConnectionlessPacket, 4p, (net_from, args, response_buffer, response_buffer_size));
 	RETURN_API(int);
 }
-static int mm_GetHullBounds(int hullnumber, float *mins, float *maxs) {
+static FORCE_STACK_ALIGN int mm_GetHullBounds(int hullnumber, float *mins, float *maxs) {
 	META_DLLAPI_HANDLE(int, 0, FN_GETHULLBOUNDS, pfnGetHullBounds, i2p, (hullnumber, mins, maxs));
 	RETURN_API(int);
 }
-static void mm_CreateInstancedBaselines (void) {
+static FORCE_STACK_ALIGN void mm_CreateInstancedBaselines (void) {
 	META_DLLAPI_HANDLE_void(FN_CREATEINSTANCEDBASELINES, pfnCreateInstancedBaselines, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static int mm_InconsistentFile(const edict_t *player, const char *filename, char *disconnect_message) {
+static FORCE_STACK_ALIGN int mm_InconsistentFile(const edict_t *player, const char *filename, char *disconnect_message) {
 	META_DLLAPI_HANDLE(int, 0, FN_INCONSISTENTFILE, pfnInconsistentFile, 3p, (player, filename, disconnect_message));
 	RETURN_API(int);
 }
-static int mm_AllowLagCompensation(void) {
+static FORCE_STACK_ALIGN int mm_AllowLagCompensation(void) {
 	META_DLLAPI_HANDLE(int, 0, FN_ALLOWLAGCOMPENSATION, pfnAllowLagCompensation, void, (VOID_ARG));
 	RETURN_API(int);
 }
@@ -317,27 +317,27 @@ static int mm_AllowLagCompensation(void) {
 
 // New API functions
 // From SDK ?
-static void mm_OnFreeEntPrivateData(edict_t *pEnt) {
+static FORCE_STACK_ALIGN void mm_OnFreeEntPrivateData(edict_t *pEnt) {
 	META_NEWAPI_HANDLE_void(FN_ONFREEENTPRIVATEDATA, pfnOnFreeEntPrivateData, p, (pEnt));
 	RETURN_API_void();
 }
-static void mm_GameShutdown(void) {
+static FORCE_STACK_ALIGN void mm_GameShutdown(void) {
 	META_NEWAPI_HANDLE_void(FN_GAMESHUTDOWN, pfnGameShutdown, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static int mm_ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
+static FORCE_STACK_ALIGN int mm_ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
 	META_NEWAPI_HANDLE(int, 1, FN_SHOULDCOLLIDE, pfnShouldCollide, 2p, (pentTouched, pentOther));
 	RETURN_API(int);
 }
 // Added 2005/08/11 (no SDK update):
-static void mm_CvarValue(const edict_t *pEnt, const char *value) {
+static FORCE_STACK_ALIGN void mm_CvarValue(const edict_t *pEnt, const char *value) {
 	g_Players.clear_player_cvar_query(pEnt);
 	META_NEWAPI_HANDLE_void(FN_CVARVALUE, pfnCvarValue, 2p, (pEnt, value));
 	
 	RETURN_API_void();
 }
 // Added 2005/11/21 (no SDK update):
-static void mm_CvarValue2(const edict_t *pEnt, int requestID, const char *cvarName, const char *value) {
+static FORCE_STACK_ALIGN void mm_CvarValue2(const edict_t *pEnt, int requestID, const char *cvarName, const char *value) {
 	META_NEWAPI_HANDLE_void(FN_CVARVALUE2, pfnCvarValue2, pi2p, (pEnt, requestID, cvarName, value));
 	
 	RETURN_API_void();

--- a/metamod/engine_api.cpp
+++ b/metamod/engine_api.cpp
@@ -120,264 +120,264 @@
 	CLEAN_FORMATED_STRING()
 
 
-static int mm_PrecacheModel(char *s) {
+static FORCE_STACK_ALIGN int mm_PrecacheModel(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHEMODEL, pfnPrecacheModel, p, (s));
 	RETURN_API(int)
 }
-static int mm_PrecacheSound(char *s) {
+static FORCE_STACK_ALIGN int mm_PrecacheSound(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHESOUND, pfnPrecacheSound, p, (s));
 	RETURN_API(int)
 }
-static void mm_SetModel(edict_t *e, const char *m) {
+static FORCE_STACK_ALIGN void mm_SetModel(edict_t *e, const char *m) {
 	META_ENGINE_HANDLE_void(FN_SETMODEL, pfnSetModel, 2p, (e, m));
 	RETURN_API_void()
 }
-static int mm_ModelIndex(const char *m) {
+static FORCE_STACK_ALIGN int mm_ModelIndex(const char *m) {
 	META_ENGINE_HANDLE(int, 0, FN_MODELINDEX, pfnModelIndex, p, (m));
 	RETURN_API(int)
 }
-static int mm_ModelFrames(int modelIndex) {
+static FORCE_STACK_ALIGN int mm_ModelFrames(int modelIndex) {
 	META_ENGINE_HANDLE(int, 0, FN_MODELFRAMES, pfnModelFrames, i, (modelIndex));
 	RETURN_API(int)
 }
 
-static void mm_SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
+static FORCE_STACK_ALIGN void mm_SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
 	META_ENGINE_HANDLE_void(FN_SETSIZE, pfnSetSize, 3p, (e, rgflMin, rgflMax));
 	RETURN_API_void()
 }
-static void mm_ChangeLevel(char *s1, char *s2) {
+static FORCE_STACK_ALIGN void mm_ChangeLevel(char *s1, char *s2) {
 	META_ENGINE_HANDLE_void(FN_CHANGELEVEL, pfnChangeLevel, 2p, (s1, s2));
 	RETURN_API_void()
 }
-static void mm_GetSpawnParms(edict_t *ent) {
+static FORCE_STACK_ALIGN void mm_GetSpawnParms(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_GETSPAWNPARMS, pfnGetSpawnParms, p, (ent));
 	RETURN_API_void()
 }
-static void mm_SaveSpawnParms(edict_t *ent) {
+static FORCE_STACK_ALIGN void mm_SaveSpawnParms(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_SAVESPAWNPARMS, pfnSaveSpawnParms, p, (ent));
 	RETURN_API_void()
 }
 
-static float mm_VecToYaw(const float *rgflVector) {
+static FORCE_STACK_ALIGN float mm_VecToYaw(const float *rgflVector) {
 	META_ENGINE_HANDLE(float, 0.0, FN_VECTOYAW, pfnVecToYaw, p, (rgflVector));
 	RETURN_API(float)
 }
-static void mm_VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
+static FORCE_STACK_ALIGN void mm_VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
 	META_ENGINE_HANDLE_void(FN_VECTOANGLES, pfnVecToAngles, 2p, (rgflVectorIn, rgflVectorOut));
 	RETURN_API_void()
 }
-static void mm_MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
+static FORCE_STACK_ALIGN void mm_MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
 	META_ENGINE_HANDLE_void(FN_MOVETOORIGIN, pfnMoveToOrigin, 2pfi, (ent, pflGoal, dist, iMoveType));
 	RETURN_API_void()
 }
-static void mm_ChangeYaw(edict_t *ent) {
+static FORCE_STACK_ALIGN void mm_ChangeYaw(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_CHANGEYAW, pfnChangeYaw, p, (ent));
 	RETURN_API_void()
 }
-static void mm_ChangePitch(edict_t *ent) {
+static FORCE_STACK_ALIGN void mm_ChangePitch(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_CHANGEPITCH, pfnChangePitch, p, (ent));
 	RETURN_API_void()
 }
 
-static edict_t *mm_FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
+static FORCE_STACK_ALIGN edict_t *mm_FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYBYSTRING, pfnFindEntityByString, 3p, (pEdictStartSearchAfter, pszField, pszValue));
 	RETURN_API(edict_t *)
 }
-static int mm_GetEntityIllum(edict_t *pEnt) {
+static FORCE_STACK_ALIGN int mm_GetEntityIllum(edict_t *pEnt) {
 	META_ENGINE_HANDLE(int, 0, FN_GETENTITYILLUM, pfnGetEntityIllum, p, (pEnt));
 	RETURN_API(int)
 }
-static edict_t *mm_FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
+static FORCE_STACK_ALIGN edict_t *mm_FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYINSPHERE, pfnFindEntityInSphere, 2pf, (pEdictStartSearchAfter, org, rad));
 	RETURN_API(edict_t *)
 }
-static edict_t *mm_FindClientInPVS(edict_t *pEdict) {
+static FORCE_STACK_ALIGN edict_t *mm_FindClientInPVS(edict_t *pEdict) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDCLIENTINPVS, pfnFindClientInPVS, p, (pEdict));
 	RETURN_API(edict_t *)
 }
-static edict_t *mm_EntitiesInPVS(edict_t *pplayer) {
+static FORCE_STACK_ALIGN edict_t *mm_EntitiesInPVS(edict_t *pplayer) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_ENTITIESINPVS, pfnEntitiesInPVS, p, (pplayer));
 	RETURN_API(edict_t *)
 }
 
-static void mm_MakeVectors(const float *rgflVector) {
+static FORCE_STACK_ALIGN void mm_MakeVectors(const float *rgflVector) {
 	META_ENGINE_HANDLE_void(FN_MAKEVECTORS, pfnMakeVectors, p, (rgflVector));
 	RETURN_API_void()
 }
-static void mm_AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
+static FORCE_STACK_ALIGN void mm_AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
 	META_ENGINE_HANDLE_void(FN_ANGLEVECTORS, pfnAngleVectors, 4p, (rgflVector, forward, right, up));
 	RETURN_API_void()
 }
 
-static edict_t *mm_CreateEntity(void) {
+static FORCE_STACK_ALIGN edict_t *mm_CreateEntity(void) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATEENTITY, pfnCreateEntity, void, (VOID_ARG));
 	RETURN_API(edict_t *)
 }
-static void mm_RemoveEntity(edict_t *e) {
+static FORCE_STACK_ALIGN void mm_RemoveEntity(edict_t *e) {
 	META_ENGINE_HANDLE_void(FN_REMOVEENTITY, pfnRemoveEntity, p, (e));
 	RETURN_API_void()
 }
-static edict_t *mm_CreateNamedEntity(int className) {
+static FORCE_STACK_ALIGN edict_t *mm_CreateNamedEntity(int className) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATENAMEDENTITY, pfnCreateNamedEntity, i, (className));
 	RETURN_API(edict_t *)
 }
 
-static void mm_MakeStatic(edict_t *ent) {
+static FORCE_STACK_ALIGN void mm_MakeStatic(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_MAKESTATIC, pfnMakeStatic, p, (ent));
 	RETURN_API_void()
 }
-static int mm_EntIsOnFloor(edict_t *e) {
+static FORCE_STACK_ALIGN int mm_EntIsOnFloor(edict_t *e) {
 	META_ENGINE_HANDLE(int, 0, FN_ENTISONFLOOR, pfnEntIsOnFloor, p, (e));
 	RETURN_API(int)
 }
-static int mm_DropToFloor(edict_t *e) {
+static FORCE_STACK_ALIGN int mm_DropToFloor(edict_t *e) {
 	META_ENGINE_HANDLE(int, 0, FN_DROPTOFLOOR, pfnDropToFloor, p, (e));
 	RETURN_API(int)
 }
 
-static int mm_WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
+static FORCE_STACK_ALIGN int mm_WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
 	META_ENGINE_HANDLE(int, 0, FN_WALKMOVE, pfnWalkMove, p2fi, (ent, yaw, dist, iMode));
 	RETURN_API(int)
 }
-static void mm_SetOrigin(edict_t *e, const float *rgflOrigin) {
+static FORCE_STACK_ALIGN void mm_SetOrigin(edict_t *e, const float *rgflOrigin) {
 	META_ENGINE_HANDLE_void(FN_SETORIGIN, pfnSetOrigin, 2p, (e, rgflOrigin));
 	RETURN_API_void()
 }
 
-static void mm_EmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch) {
+static FORCE_STACK_ALIGN void mm_EmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch) {
 	META_ENGINE_HANDLE_void(FN_EMITSOUND, pfnEmitSound, pip2f2i, (entity, channel, sample, volume, attenuation, fFlags, pitch));
 	RETURN_API_void()
 }
-static void mm_EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
+static FORCE_STACK_ALIGN void mm_EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
 	META_ENGINE_HANDLE_void(FN_EMITAMBIENTSOUND, pfnEmitAmbientSound, 3p2f2i, (entity, pos, samp, vol, attenuation, fFlags, pitch));
 	RETURN_API_void()
 }
 
-static void mm_TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+static FORCE_STACK_ALIGN void mm_TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACELINE, pfnTraceLine, 2pi2p, (v1, v2, fNoMonsters, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static void mm_TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
+static FORCE_STACK_ALIGN void mm_TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACETOSS, pfnTraceToss, 3p, (pent, pentToIgnore, ptr));
 	RETURN_API_void()
 }
-static int mm_TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+static FORCE_STACK_ALIGN int mm_TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE(int, 0, FN_TRACEMONSTERHULL, pfnTraceMonsterHull, 3pi2p, (pEdict, v1, v2, fNoMonsters, pentToSkip, ptr));
 	RETURN_API(int)
 }
-static void mm_TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
+static FORCE_STACK_ALIGN void mm_TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACEHULL, pfnTraceHull, 2p2i2p, (v1, v2, fNoMonsters, hullNumber, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static void mm_TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
+static FORCE_STACK_ALIGN void mm_TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACEMODEL, pfnTraceModel, 2pi2p, (v1, v2, hullNumber, pent, ptr));
 	RETURN_API_void()
 }
-static const char *mm_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
+static FORCE_STACK_ALIGN const char *mm_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_TRACETEXTURE, pfnTraceTexture, 3p, (pTextureEntity, v1, v2));
 	RETURN_API(const char *)
 }
-static void mm_TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
+static FORCE_STACK_ALIGN void mm_TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACESPHERE, pfnTraceSphere, 2pif2p, (v1, v2, fNoMonsters, radius, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static void mm_GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
+static FORCE_STACK_ALIGN void mm_GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
 	META_ENGINE_HANDLE_void(FN_GETAIMVECTOR, pfnGetAimVector, pfp, (ent, speed, rgflReturn));
 	RETURN_API_void()
 }
 
-static void mm_ServerCommand(char *str) {
+static FORCE_STACK_ALIGN void mm_ServerCommand(char *str) {
 	META_ENGINE_HANDLE_void(FN_SERVERCOMMAND, pfnServerCommand, p, (str));
 	RETURN_API_void()
 }
-static void mm_ServerExecute(void) {
+static FORCE_STACK_ALIGN void mm_ServerExecute(void) {
 	META_ENGINE_HANDLE_void(FN_SERVEREXECUTE, pfnServerExecute, void, (VOID_ARG));
 	RETURN_API_void()
 }
-static void mm_engClientCommand(edict_t *pEdict, char *szFmt, ...) {
+static FORCE_STACK_ALIGN void mm_engClientCommand(edict_t *pEdict, char *szFmt, ...) {
 	META_ENGINE_HANDLE_void_varargs(FN_CLIENTCOMMAND_ENG, pfnClientCommand, 2pV, pEdict, szFmt);
 	RETURN_API_void()
 }
 
-static void mm_ParticleEffect(const float *org, const float *dir, float color, float count) {
+static FORCE_STACK_ALIGN void mm_ParticleEffect(const float *org, const float *dir, float color, float count) {
 	META_ENGINE_HANDLE_void(FN_PARTICLEEFFECT, pfnParticleEffect, 2p2f, (org, dir, color, count));
 	RETURN_API_void()
 }
-static void mm_LightStyle(int style, char *val) {
+static FORCE_STACK_ALIGN void mm_LightStyle(int style, char *val) {
 	META_ENGINE_HANDLE_void(FN_LIGHTSTYLE, pfnLightStyle, ip, (style, val));
 	RETURN_API_void()
 }
-static int mm_DecalIndex(const char *name) {
+static FORCE_STACK_ALIGN int mm_DecalIndex(const char *name) {
 	META_ENGINE_HANDLE(int, 0, FN_DECALINDEX, pfnDecalIndex, p, (name));
 	RETURN_API(int)
 }
-static int mm_PointContents(const float *rgflVector) {
+static FORCE_STACK_ALIGN int mm_PointContents(const float *rgflVector) {
 	META_ENGINE_HANDLE(int, 0, FN_POINTCONTENTS, pfnPointContents, p, (rgflVector));
 	RETURN_API(int)
 }
 
-static void mm_MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
+static FORCE_STACK_ALIGN void mm_MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
 	META_ENGINE_HANDLE_void(FN_MESSAGEBEGIN, pfnMessageBegin, 2i2p, (msg_dest, msg_type, pOrigin, ed));
 	RETURN_API_void()
 }
-static void mm_MessageEnd(void) {
+static FORCE_STACK_ALIGN void mm_MessageEnd(void) {
 	META_ENGINE_HANDLE_void(FN_MESSAGEEND, pfnMessageEnd, void, (VOID_ARG));
 	RETURN_API_void()
 }
 
-static void mm_WriteByte(int iValue) {
+static FORCE_STACK_ALIGN void mm_WriteByte(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEBYTE, pfnWriteByte, i, (iValue));
 	RETURN_API_void()
 }
-static void mm_WriteChar(int iValue) {
+static FORCE_STACK_ALIGN void mm_WriteChar(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITECHAR, pfnWriteChar, i, (iValue));
 	RETURN_API_void()
 }
-static void mm_WriteShort(int iValue) {
+static FORCE_STACK_ALIGN void mm_WriteShort(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITESHORT, pfnWriteShort, i, (iValue));
 	RETURN_API_void()
 }
-static void mm_WriteLong(int iValue) {
+static FORCE_STACK_ALIGN void mm_WriteLong(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITELONG, pfnWriteLong, i, (iValue));
 	RETURN_API_void()
 }
-static void mm_WriteAngle(float flValue) {
+static FORCE_STACK_ALIGN void mm_WriteAngle(float flValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEANGLE, pfnWriteAngle, f, (flValue));
 	RETURN_API_void()
 }
-static void mm_WriteCoord(float flValue) {
+static FORCE_STACK_ALIGN void mm_WriteCoord(float flValue) {
 	META_ENGINE_HANDLE_void(FN_WRITECOORD, pfnWriteCoord, f, (flValue));
 	RETURN_API_void()
 }
-static void mm_WriteString(const char *sz) {
+static FORCE_STACK_ALIGN void mm_WriteString(const char *sz) {
 	META_ENGINE_HANDLE_void(FN_WRITESTRING, pfnWriteString, p, (sz));
 	RETURN_API_void()
 }
-static void mm_WriteEntity(int iValue) {
+static FORCE_STACK_ALIGN void mm_WriteEntity(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEENTITY, pfnWriteEntity, i, (iValue));
 	RETURN_API_void()
 }
 
-static void mm_CVarRegister(cvar_t *pCvar) {
+static FORCE_STACK_ALIGN void mm_CVarRegister(cvar_t *pCvar) {
 	META_ENGINE_HANDLE_void(FN_CVARREGISTER, pfnCVarRegister, p, (pCvar));
 	RETURN_API_void()
 }
-static float mm_CVarGetFloat(const char *szVarName) {
+static FORCE_STACK_ALIGN float mm_CVarGetFloat(const char *szVarName) {
 	META_ENGINE_HANDLE(float, 0.0, FN_CVARGETFLOAT, pfnCVarGetFloat, p, (szVarName));
 	RETURN_API(float)
 }
-static const char *mm_CVarGetString(const char *szVarName) {
+static FORCE_STACK_ALIGN const char *mm_CVarGetString(const char *szVarName) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CVARGETSTRING, pfnCVarGetString, p, (szVarName));
 	RETURN_API(const char *)
 }
-static void mm_CVarSetFloat(const char *szVarName, float flValue) {
+static FORCE_STACK_ALIGN void mm_CVarSetFloat(const char *szVarName, float flValue) {
 	META_ENGINE_HANDLE_void(FN_CVARSETFLOAT, pfnCVarSetFloat, pf, (szVarName, flValue));
 
 	meta_debug_value = (int)meta_debug.value;
 
 	RETURN_API_void()
 }
-static void mm_CVarSetString(const char *szVarName, const char *szValue) {
+static FORCE_STACK_ALIGN void mm_CVarSetString(const char *szVarName, const char *szValue) {
 	META_ENGINE_HANDLE_void(FN_CVARSETSTRING, pfnCVarSetString, 2p, (szVarName, szValue));
 
 	meta_debug_value = (int)meta_debug.value;
@@ -385,75 +385,75 @@ static void mm_CVarSetString(const char *szVarName, const char *szValue) {
 	RETURN_API_void()
 }
 
-static void mm_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
+static FORCE_STACK_ALIGN void mm_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	META_ENGINE_HANDLE_void_varargs(FN_ALERTMESSAGE, pfnAlertMessage, ipV, atype, szFmt);
 	RETURN_API_void()
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-static void mm_EngineFprintf(FILE *pfile, char *szFmt, ...) {
+static FORCE_STACK_ALIGN void mm_EngineFprintf(FILE *pfile, char *szFmt, ...) {
 #else
-static void mm_EngineFprintf(void *pfile, char *szFmt, ...) {
+static FORCE_STACK_ALIGN void mm_EngineFprintf(void *pfile, char *szFmt, ...) {
 #endif
 	META_ENGINE_HANDLE_void_varargs(FN_ENGINEFPRINTF, pfnEngineFprintf, 2pV, pfile, szFmt);
 	RETURN_API_void()
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static void *mm_PvAllocEntPrivateData(edict_t *pEdict, long cb) {
+static FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, long cb) {
 #else
-static void *mm_PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
+static FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
 #endif
 	META_ENGINE_HANDLE(void *, NULL, FN_PVALLOCENTPRIVATEDATA, pfnPvAllocEntPrivateData, pi, (pEdict, cb));
 	RETURN_API(void *)
 }
-static void *mm_PvEntPrivateData(edict_t *pEdict) {
+static FORCE_STACK_ALIGN void *mm_PvEntPrivateData(edict_t *pEdict) {
 	META_ENGINE_HANDLE(void *, NULL, FN_PVENTPRIVATEDATA, pfnPvEntPrivateData, p, (pEdict));
 	RETURN_API(void *)
 }
-static void mm_FreeEntPrivateData(edict_t *pEdict) {
+static FORCE_STACK_ALIGN void mm_FreeEntPrivateData(edict_t *pEdict) {
 	META_ENGINE_HANDLE_void(FN_FREEENTPRIVATEDATA, pfnFreeEntPrivateData, p, (pEdict));
 	RETURN_API_void()
 }
 
-static const char *mm_SzFromIndex(int iString) {
+static FORCE_STACK_ALIGN const char *mm_SzFromIndex(int iString) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_SZFROMINDEX, pfnSzFromIndex, i, (iString));
 	RETURN_API(const char *)
 }
-static int mm_AllocString(const char *szValue) {
+static FORCE_STACK_ALIGN int mm_AllocString(const char *szValue) {
 	META_ENGINE_HANDLE(int, 0, FN_ALLOCSTRING, pfnAllocString, p, (szValue));
 	RETURN_API(int)
 }
 
-static struct entvars_s *mm_GetVarsOfEnt(edict_t *pEdict) {
+static FORCE_STACK_ALIGN struct entvars_s *mm_GetVarsOfEnt(edict_t *pEdict) {
 	META_ENGINE_HANDLE(struct entvars_s *, NULL, FN_GETVARSOFENT, pfnGetVarsOfEnt, p, (pEdict));
 	RETURN_API(struct entvars_s *)
 }
-static edict_t *mm_PEntityOfEntOffset(int iEntOffset) {
+static FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntOffset(int iEntOffset) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_PENTITYOFENTOFFSET, pfnPEntityOfEntOffset, i, (iEntOffset));
 	RETURN_API(edict_t *)
 }
-static int mm_EntOffsetOfPEntity(const edict_t *pEdict) {
+static FORCE_STACK_ALIGN int mm_EntOffsetOfPEntity(const edict_t *pEdict) {
 	META_ENGINE_HANDLE(int, 0, FN_ENTOFFSETOFPENTITY, pfnEntOffsetOfPEntity, p, (pEdict));
 	RETURN_API(int)
 }
-static int mm_IndexOfEdict(const edict_t *pEdict) {
+static FORCE_STACK_ALIGN int mm_IndexOfEdict(const edict_t *pEdict) {
 	META_ENGINE_HANDLE(int, 0, FN_INDEXOFEDICT, pfnIndexOfEdict, p, (pEdict));
 	RETURN_API(int)
 }
-static edict_t *mm_PEntityOfEntIndex(int iEntIndex) {
+static FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntIndex(int iEntIndex) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_PENTITYOFENTINDEX, pfnPEntityOfEntIndex, i, (iEntIndex));
 	RETURN_API(edict_t *)
 }
-static edict_t *mm_FindEntityByVars(struct entvars_s *pvars) {
+static FORCE_STACK_ALIGN edict_t *mm_FindEntityByVars(struct entvars_s *pvars) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYBYVARS, pfnFindEntityByVars, p, (pvars));
 	RETURN_API(edict_t *)
 }
-static void *mm_GetModelPtr(edict_t *pEdict) {
+static FORCE_STACK_ALIGN void *mm_GetModelPtr(edict_t *pEdict) {
 	META_ENGINE_HANDLE(void *, NULL, FN_GETMODELPTR, pfnGetModelPtr, p, (pEdict));
 	RETURN_API(void *)
 }
 
-static int mm_RegUserMsg(const char *pszName, int iSize) {
+static FORCE_STACK_ALIGN int mm_RegUserMsg(const char *pszName, int iSize) {
 	int imsgid;
 	MRegMsg *nmsg=NULL;
 	META_ENGINE_HANDLE(int, 0, FN_REGUSERMSG, pfnRegUserMsg, pi, (pszName, iSize));
@@ -482,296 +482,296 @@ static int mm_RegUserMsg(const char *pszName, int iSize) {
 	return(imsgid);
 }
 
-static void mm_AnimationAutomove(const edict_t *pEdict, float flTime) {
+static FORCE_STACK_ALIGN void mm_AnimationAutomove(const edict_t *pEdict, float flTime) {
 	META_ENGINE_HANDLE_void(FN_ANIMATIONAUTOMOVE, pfnAnimationAutomove, pf, (pEdict, flTime));
 	RETURN_API_void()
 }
-static void mm_GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
+static FORCE_STACK_ALIGN void mm_GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
 	META_ENGINE_HANDLE_void(FN_GETBONEPOSITION, pfnGetBonePosition, pi2p, (pEdict, iBone, rgflOrigin, rgflAngles));
 	RETURN_API_void()
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static unsigned long mm_FunctionFromName( const char *pName ) {
+static FORCE_STACK_ALIGN unsigned long mm_FunctionFromName( const char *pName ) {
 	META_ENGINE_HANDLE(unsigned long, 0, FN_FUNCTIONFROMNAME, pfnFunctionFromName, p, (pName));
 	RETURN_API(unsigned long)
 }
 #else
-static uint32 mm_FunctionFromName( const char *pName ) {
+static FORCE_STACK_ALIGN uint32 mm_FunctionFromName( const char *pName ) {
 	META_ENGINE_HANDLE(uint32, 0, FN_FUNCTIONFROMNAME, pfnFunctionFromName, p, (pName));
 	RETURN_API(uint32)
 }
 #endif
 #ifdef HLSDK_3_2_OLD_EIFACE
-static const char *mm_NameForFunction( unsigned long function ) {
+static FORCE_STACK_ALIGN const char *mm_NameForFunction( unsigned long function ) {
 #else
-static const char *mm_NameForFunction( uint32 function ) {
+static FORCE_STACK_ALIGN const char *mm_NameForFunction( uint32 function ) {
 #endif
 	META_ENGINE_HANDLE(const char *, NULL, FN_NAMEFORFUNCTION, pfnNameForFunction, ui, (function));
 	RETURN_API(const char *)
 }
 
 //! JOHN: engine callbacks so game DLL can print messages to individual clients
-static void mm_ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
+static FORCE_STACK_ALIGN void mm_ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
 	META_ENGINE_HANDLE_void(FN_CLIENTPRINTF, pfnClientPrintf, pip, (pEdict, ptype, szMsg));
 	RETURN_API_void()
 }
-static void mm_ServerPrint( const char *szMsg ) {
+static FORCE_STACK_ALIGN void mm_ServerPrint( const char *szMsg ) {
 	META_ENGINE_HANDLE_void(FN_SERVERPRINT, pfnServerPrint, p, (szMsg));
 	RETURN_API_void()
 }
 
 //! these 3 added so game DLL can easily access client 'cmd' strings
-static const char *mm_Cmd_Args( void ) {
+static FORCE_STACK_ALIGN const char *mm_Cmd_Args( void ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CMD_ARGS, pfnCmd_Args, void, (VOID_ARG));
 	RETURN_API(const char *)
 }
-static const char *mm_Cmd_Argv( int argc ) {
+static FORCE_STACK_ALIGN const char *mm_Cmd_Argv( int argc ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CMD_ARGV, pfnCmd_Argv, i, (argc));
 	RETURN_API(const char *)
 }
-static int mm_Cmd_Argc( void ) {
+static FORCE_STACK_ALIGN int mm_Cmd_Argc( void ) {
 	META_ENGINE_HANDLE(int, 0, FN_CMD_ARGC, pfnCmd_Argc, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
-static void mm_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
+static FORCE_STACK_ALIGN void mm_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
 	META_ENGINE_HANDLE_void(FN_GETATTACHMENT, pfnGetAttachment, pi2p, (pEdict, iAttachment, rgflOrigin, rgflAngles));
 	RETURN_API_void()
 }
 
-static void mm_CRC32_Init(CRC32_t *pulCRC) {
+static FORCE_STACK_ALIGN void mm_CRC32_Init(CRC32_t *pulCRC) {
 	META_ENGINE_HANDLE_void(FN_CRC32_INIT, pfnCRC32_Init, p, (pulCRC));
 	RETURN_API_void()
 }
-static void mm_CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
+static FORCE_STACK_ALIGN void mm_CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
 	META_ENGINE_HANDLE_void(FN_CRC32_PROCESSBUFFER, pfnCRC32_ProcessBuffer, 2pi, (pulCRC, p, len));
 	RETURN_API_void()
 }
-static void mm_CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
+static FORCE_STACK_ALIGN void mm_CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
 	META_ENGINE_HANDLE_void(FN_CRC32_PROCESSBYTE, pfnCRC32_ProcessByte, puc, (pulCRC, ch));
 	RETURN_API_void()
 }
-static CRC32_t mm_CRC32_Final(CRC32_t pulCRC) {
+static FORCE_STACK_ALIGN CRC32_t mm_CRC32_Final(CRC32_t pulCRC) {
 	META_ENGINE_HANDLE(CRC32_t, 0, FN_CRC32_FINAL, pfnCRC32_Final, ul, (pulCRC));
 	RETURN_API(CRC32_t)
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static long mm_RandomLong(long lLow, long lHigh) {
+static FORCE_STACK_ALIGN long mm_RandomLong(long lLow, long lHigh) {
 	META_ENGINE_HANDLE(long, 0, FN_RANDOMLONG, pfnRandomLong, 2i, (lLow, lHigh));
 	RETURN_API(long)
 }
 #else
-static int32 mm_RandomLong(int32 lLow, int32 lHigh) {
+static FORCE_STACK_ALIGN int32 mm_RandomLong(int32 lLow, int32 lHigh) {
 	META_ENGINE_HANDLE(int32, 0, FN_RANDOMLONG, pfnRandomLong, 2i, (lLow, lHigh));
 	RETURN_API(int32)
 }
 #endif
-static float mm_RandomFloat(float flLow, float flHigh) {
+static FORCE_STACK_ALIGN float mm_RandomFloat(float flLow, float flHigh) {
 	META_ENGINE_HANDLE(float, 0.0, FN_RANDOMFLOAT, pfnRandomFloat, 2f, (flLow, flHigh));
 	RETURN_API(float)
 }
 
-static void mm_SetView(const edict_t *pClient, const edict_t *pViewent ) {
+static FORCE_STACK_ALIGN void mm_SetView(const edict_t *pClient, const edict_t *pViewent ) {
 	META_ENGINE_HANDLE_void(FN_SETVIEW, pfnSetView, 2p, (pClient, pViewent));
 	RETURN_API_void()
 }
-static float mm_Time( void ) {
+static FORCE_STACK_ALIGN float mm_Time( void ) {
 	META_ENGINE_HANDLE(float, 0.0, FN_TIME, pfnTime, void, (VOID_ARG));
 	RETURN_API(float)
 }
-static void mm_CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
+static FORCE_STACK_ALIGN void mm_CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
 	META_ENGINE_HANDLE_void(FN_CROSSHAIRANGLE, pfnCrosshairAngle, p2f, (pClient, pitch, yaw));
 	RETURN_API_void()
 }
 
-static byte * mm_LoadFileForMe(char *filename, int *pLength) {
+static FORCE_STACK_ALIGN byte * mm_LoadFileForMe(char *filename, int *pLength) {
 	META_ENGINE_HANDLE(byte *, NULL, FN_LOADFILEFORME, pfnLoadFileForMe, 2p, (filename, pLength));
 	RETURN_API(byte *)
 }
-static void mm_FreeFile(void *buffer) {
+static FORCE_STACK_ALIGN void mm_FreeFile(void *buffer) {
 	META_ENGINE_HANDLE_void(FN_FREEFILE, pfnFreeFile, p, (buffer));
 	RETURN_API_void()
 }
 
 //! trigger_endsection
-static void mm_EndSection(const char *pszSectionName) {
+static FORCE_STACK_ALIGN void mm_EndSection(const char *pszSectionName) {
 	META_ENGINE_HANDLE_void(FN_ENDSECTION, pfnEndSection, p, (pszSectionName));
 	RETURN_API_void()
 }
-static int mm_CompareFileTime(char *filename1, char *filename2, int *iCompare) {
+static FORCE_STACK_ALIGN int mm_CompareFileTime(char *filename1, char *filename2, int *iCompare) {
 	META_ENGINE_HANDLE(int, 0, FN_COMPAREFILETIME, pfnCompareFileTime, 3p, (filename1, filename2, iCompare));
 	RETURN_API(int)
 }
-static void mm_GetGameDir(char *szGetGameDir) {
+static FORCE_STACK_ALIGN void mm_GetGameDir(char *szGetGameDir) {
 	META_ENGINE_HANDLE_void(FN_GETGAMEDIR, pfnGetGameDir, p, (szGetGameDir));
 	RETURN_API_void()
 }
-static void mm_Cvar_RegisterVariable(cvar_t *variable) {
+static FORCE_STACK_ALIGN void mm_Cvar_RegisterVariable(cvar_t *variable) {
 	META_ENGINE_HANDLE_void(FN_CVAR_REGISTERVARIABLE, pfnCvar_RegisterVariable, p, (variable));
 	RETURN_API_void()
 }
-static void mm_FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
+static FORCE_STACK_ALIGN void mm_FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
 	META_ENGINE_HANDLE_void(FN_FADECLIENTVOLUME, pfnFadeClientVolume, p4i, (pEdict, fadePercent, fadeOutSeconds, holdTime, fadeInSeconds));
 	RETURN_API_void()
 }
-static void mm_SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
+static FORCE_STACK_ALIGN void mm_SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
 	META_ENGINE_HANDLE_void(FN_SETCLIENTMAXSPEED, pfnSetClientMaxspeed, pf, (pEdict, fNewMaxspeed));
 	RETURN_API_void()
 }
 //! returns NULL if fake client can't be created
-static edict_t * mm_CreateFakeClient(const char *netname) {
+static FORCE_STACK_ALIGN edict_t * mm_CreateFakeClient(const char *netname) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATEFAKECLIENT, pfnCreateFakeClient, p, (netname));
 	RETURN_API(edict_t *)
 }
-static void mm_RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
+static FORCE_STACK_ALIGN void mm_RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
 	META_ENGINE_HANDLE_void(FN_RUNPLAYERMOVE, pfnRunPlayerMove, 2p3fus2uc, (fakeclient, viewangles, forwardmove, sidemove, upmove, buttons, impulse, msec));
 	RETURN_API_void()
 }
-static int mm_NumberOfEntities(void) {
+static FORCE_STACK_ALIGN int mm_NumberOfEntities(void) {
 	META_ENGINE_HANDLE(int, 0, FN_NUMBEROFENTITIES, pfnNumberOfEntities, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
 //! passing in NULL gets the serverinfo
-static char *mm_GetInfoKeyBuffer(edict_t *e) {
+static FORCE_STACK_ALIGN char *mm_GetInfoKeyBuffer(edict_t *e) {
 	META_ENGINE_HANDLE(char *, NULL, FN_GETINFOKEYBUFFER, pfnGetInfoKeyBuffer, p, (e));
 	RETURN_API(char *)
 }
-static char *mm_InfoKeyValue(char *infobuffer, char *key) {
+static FORCE_STACK_ALIGN char *mm_InfoKeyValue(char *infobuffer, char *key) {
 	META_ENGINE_HANDLE(char *, NULL, FN_INFOKEYVALUE, pfnInfoKeyValue, 2p, (infobuffer, key));
 	RETURN_API(char *)
 }
-static void mm_SetKeyValue(char *infobuffer, char *key, char *value) {
+static FORCE_STACK_ALIGN void mm_SetKeyValue(char *infobuffer, char *key, char *value) {
 	META_ENGINE_HANDLE_void(FN_SETKEYVALUE, pfnSetKeyValue, 3p, (infobuffer, key, value));
 	RETURN_API_void()
 }
-static void mm_SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
+static FORCE_STACK_ALIGN void mm_SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
 	META_ENGINE_HANDLE_void(FN_SETCLIENTKEYVALUE, pfnSetClientKeyValue, i3p, (clientIndex, infobuffer, key, value));
 	RETURN_API_void()
 }
 
-static int mm_IsMapValid(char *filename) {
+static FORCE_STACK_ALIGN int mm_IsMapValid(char *filename) {
 	META_ENGINE_HANDLE(int, 0, FN_ISMAPVALID, pfnIsMapValid, p, (filename));
 	RETURN_API(int)
 }
-static void mm_StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
+static FORCE_STACK_ALIGN void mm_StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
 	META_ENGINE_HANDLE_void(FN_STATICDECAL, pfnStaticDecal, p3i, (origin, decalIndex, entityIndex, modelIndex));
 	RETURN_API_void()
 }
-static int mm_PrecacheGeneric(char *s) {
+static FORCE_STACK_ALIGN int mm_PrecacheGeneric(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHEGENERIC, pfnPrecacheGeneric, p, (s));
 	RETURN_API(int)
 }
 //! returns the server assigned userid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-static int mm_GetPlayerUserId(edict_t *e ) {
+static FORCE_STACK_ALIGN int mm_GetPlayerUserId(edict_t *e ) {
 	META_ENGINE_HANDLE(int, 0, FN_GETPLAYERUSERID, pfnGetPlayerUserId, p, (e));
 	RETURN_API(int)
 }
-static void mm_BuildSoundMsg(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch, int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) 
+static FORCE_STACK_ALIGN void mm_BuildSoundMsg(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch, int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) 
 {
 	META_ENGINE_HANDLE_void(FN_BUILDSOUNDMSG, pfnBuildSoundMsg, pip2f4i2p, (entity, channel, sample, volume, attenuation, fFlags, pitch, msg_dest, msg_type, pOrigin, ed));
 	RETURN_API_void()
 }
 //! is this a dedicated server?
-static int mm_IsDedicatedServer(void) {
+static FORCE_STACK_ALIGN int mm_IsDedicatedServer(void) {
 	META_ENGINE_HANDLE(int, 0, FN_ISDEDICATEDSERVER, pfnIsDedicatedServer, void, (VOID_ARG));
 	RETURN_API(int)
 }
-static cvar_t *mm_CVarGetPointer(const char *szVarName) {
+static FORCE_STACK_ALIGN cvar_t *mm_CVarGetPointer(const char *szVarName) {
 	META_ENGINE_HANDLE(cvar_t *, NULL, FN_CVARGETPOINTER, pfnCVarGetPointer, p, (szVarName));
 	RETURN_API(cvar_t *)
 }
 //! returns the server assigned WONid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-static unsigned int mm_GetPlayerWONId(edict_t *e) {
+static FORCE_STACK_ALIGN unsigned int mm_GetPlayerWONId(edict_t *e) {
 	META_ENGINE_HANDLE(unsigned int, 0, FN_GETPLAYERWONID, pfnGetPlayerWONId, p, (e));
 	RETURN_API(unsigned int)
 }
 
 //! YWB 8/1/99 TFF Physics additions
-static void mm_Info_RemoveKey( char *s, const char *key ) {
+static FORCE_STACK_ALIGN void mm_Info_RemoveKey( char *s, const char *key ) {
 	META_ENGINE_HANDLE_void(FN_INFO_REMOVEKEY, pfnInfo_RemoveKey, 2p, (s, key));
 	RETURN_API_void()
 }
-static const char *mm_GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
+static FORCE_STACK_ALIGN const char *mm_GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPHYSICSKEYVALUE, pfnGetPhysicsKeyValue, 2p, (pClient, key));
 	RETURN_API(const char *)
 }
-static void mm_SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
+static FORCE_STACK_ALIGN void mm_SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
 	META_ENGINE_HANDLE_void(FN_SETPHYSICSKEYVALUE, pfnSetPhysicsKeyValue, 3p, (pClient, key, value));
 	RETURN_API_void()
 }
-static const char *mm_GetPhysicsInfoString( const edict_t *pClient ) {
+static FORCE_STACK_ALIGN const char *mm_GetPhysicsInfoString( const edict_t *pClient ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPHYSICSINFOSTRING, pfnGetPhysicsInfoString, p, (pClient));
 	RETURN_API(const char *)
 }
-static unsigned short mm_PrecacheEvent( int type, const char *psz ) {
+static FORCE_STACK_ALIGN unsigned short mm_PrecacheEvent( int type, const char *psz ) {
 	META_ENGINE_HANDLE(unsigned short, 0, FN_PRECACHEEVENT, pfnPrecacheEvent, ip, (type, psz));
 	RETURN_API(unsigned short)
 }
-static void mm_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 ) {
+static FORCE_STACK_ALIGN void mm_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 ) {
 	META_ENGINE_HANDLE_void(FN_PLAYBACKEVENT, pfnPlaybackEvent, ipusf2p2f4i, (flags, pInvoker, eventindex, delay, origin, angles, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2));
 	RETURN_API_void()
 }
 
-static unsigned char *mm_SetFatPVS( float *org ) {
+static FORCE_STACK_ALIGN unsigned char *mm_SetFatPVS( float *org ) {
 	META_ENGINE_HANDLE(unsigned char *, 0, FN_SETFATPVS, pfnSetFatPVS, p, (org));
 	RETURN_API(unsigned char *)
 }
-static unsigned char *mm_SetFatPAS( float *org ) {
+static FORCE_STACK_ALIGN unsigned char *mm_SetFatPAS( float *org ) {
 	META_ENGINE_HANDLE(unsigned char *, 0, FN_SETFATPAS, pfnSetFatPAS, p, (org));
 	RETURN_API(unsigned char *)
 }
 
-static int mm_CheckVisibility( const edict_t *entity, unsigned char *pset ) {
+static FORCE_STACK_ALIGN int mm_CheckVisibility( const edict_t *entity, unsigned char *pset ) {
 	META_ENGINE_HANDLE(int, 0, FN_CHECKVISIBILITY, pfnCheckVisibility, 2p, (entity, pset));
 	RETURN_API(int)
 }
 
-static void mm_DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
+static FORCE_STACK_ALIGN void mm_DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE_void(FN_DELTASETFIELD, pfnDeltaSetField, 2p, (pFields, fieldname));
 	RETURN_API_void()
 }
-static void mm_DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
+static FORCE_STACK_ALIGN void mm_DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE_void(FN_DELTAUNSETFIELD, pfnDeltaUnsetField, 2p, (pFields, fieldname));
 	RETURN_API_void()
 }
-static void mm_DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
+static FORCE_STACK_ALIGN void mm_DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
 	META_ENGINE_HANDLE_void(FN_DELTAADDENCODER, pfnDeltaAddEncoder, 2p, (name, (void*)conditionalencode));
 	RETURN_API_void()
 }
-static int mm_GetCurrentPlayer( void ) {
+static FORCE_STACK_ALIGN int mm_GetCurrentPlayer( void ) {
 	META_ENGINE_HANDLE(int, 0, FN_GETCURRENTPLAYER, pfnGetCurrentPlayer, void, (VOID_ARG));
 	RETURN_API(int)
 }
-static int mm_CanSkipPlayer( const edict_t *player ) {
+static FORCE_STACK_ALIGN int mm_CanSkipPlayer( const edict_t *player ) {
 	META_ENGINE_HANDLE(int, 0, FN_CANSKIPPLAYER, pfnCanSkipPlayer, p, (player));
 	RETURN_API(int)
 }
-static int mm_DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
+static FORCE_STACK_ALIGN int mm_DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE(int, 0, FN_DELTAFINDFIELD, pfnDeltaFindField, 2p, (pFields, fieldname));
 	RETURN_API(int)
 }
-static void mm_DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+static FORCE_STACK_ALIGN void mm_DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	META_ENGINE_HANDLE_void(FN_DELTASETFIELDBYINDEX, pfnDeltaSetFieldByIndex, pi, (pFields, fieldNumber));
 	RETURN_API_void()
 }
-static void mm_DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+static FORCE_STACK_ALIGN void mm_DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	META_ENGINE_HANDLE_void(FN_DELTAUNSETFIELDBYINDEX, pfnDeltaUnsetFieldByIndex, pi, (pFields, fieldNumber));
 	RETURN_API_void()
 }
 
-static void mm_SetGroupMask( int mask, int op ) {
+static FORCE_STACK_ALIGN void mm_SetGroupMask( int mask, int op ) {
 	META_ENGINE_HANDLE_void(FN_SETGROUPMASK, pfnSetGroupMask, 2i, (mask, op));
 	RETURN_API_void()
 }
 
-static int mm_engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
+static FORCE_STACK_ALIGN int mm_engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
 	META_ENGINE_HANDLE(int, 0, FN_CREATEINSTANCEDBASELINE, pfnCreateInstancedBaseline, ip, (classname, baseline));
 	RETURN_API(int)
 }
-static void mm_Cvar_DirectSet( struct cvar_s *var, char *value ) {
+static FORCE_STACK_ALIGN void mm_Cvar_DirectSet( struct cvar_s *var, char *value ) {
 	META_ENGINE_HANDLE_void(FN_CVAR_DIRECTSET, pfnCvar_DirectSet, 2p, (var, value));
 
 	meta_debug_value = (int)meta_debug.value;
@@ -782,17 +782,17 @@ static void mm_Cvar_DirectSet( struct cvar_s *var, char *value ) {
 //! Forces the client and server to be running with the same version of the specified file
 //!( e.g., a player model ).
 //! Calling this has no effect in single player
-static void mm_ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
+static FORCE_STACK_ALIGN void mm_ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
 	META_ENGINE_HANDLE_void(FN_FORCEUNMODIFIED, pfnForceUnmodified, i3p, (type, mins, maxs, filename));
 	RETURN_API_void()
 }
 
-static void mm_GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
+static FORCE_STACK_ALIGN void mm_GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
 	META_ENGINE_HANDLE_void(FN_GETPLAYERSTATS, pfnGetPlayerStats, 3p, (pClient, ping, packet_loss));
 	RETURN_API_void()
 }
 
-static void mm_AddServerCommand( char *cmd_name, void (*function) (void) ) {
+static FORCE_STACK_ALIGN void mm_AddServerCommand( char *cmd_name, void (*function) (void) ) {
 	META_ENGINE_HANDLE_void(FN_ADDSERVERCOMMAND, pfnAddServerCommand, 2p, (cmd_name, (void*)function));
 	RETURN_API_void()
 }
@@ -801,81 +801,81 @@ static void mm_AddServerCommand( char *cmd_name, void (*function) (void) ) {
 
 //! For voice communications, set which clients hear eachother.
 //! NOTE: these functions take player entity indices (starting at 1).
-static qboolean mm_Voice_GetClientListening(int iReceiver, int iSender) {
+static FORCE_STACK_ALIGN qboolean mm_Voice_GetClientListening(int iReceiver, int iSender) {
 	META_ENGINE_HANDLE(qboolean, false, FN_VOICE_GETCLIENTLISTENING, pfnVoice_GetClientListening, 2i, (iReceiver, iSender));
 	RETURN_API(qboolean)
 }
-static qboolean mm_Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
+static FORCE_STACK_ALIGN qboolean mm_Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
 	META_ENGINE_HANDLE(qboolean, false, FN_VOICE_SETCLIENTLISTENING, pfnVoice_SetClientListening, 3i, (iReceiver, iSender, bListen));
 	RETURN_API(qboolean)
 }
 
 // Added for HL 1109 (no SDK update):
 
-static const char *mm_GetPlayerAuthId(edict_t *e) {
+static FORCE_STACK_ALIGN const char *mm_GetPlayerAuthId(edict_t *e) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPLAYERAUTHID, pfnGetPlayerAuthId, p, (e));
 	RETURN_API(const char *)
 }
 
 // Added 2003/11/10 (no SDK update):
 
-static sequenceEntry_s *mm_SequenceGet(const char *fileName, const char *entryName) {
+static FORCE_STACK_ALIGN sequenceEntry_s *mm_SequenceGet(const char *fileName, const char *entryName) {
 	META_ENGINE_HANDLE(sequenceEntry_s *, NULL, FN_SEQUENCEGET, pfnSequenceGet, 2p, (fileName, entryName));
 	RETURN_API(sequenceEntry_s *)
 }
 
-static sentenceEntry_s *mm_SequencePickSentence(const char *groupName, int pickMethod, int *picked) {
+static FORCE_STACK_ALIGN sentenceEntry_s *mm_SequencePickSentence(const char *groupName, int pickMethod, int *picked) {
 	META_ENGINE_HANDLE(sentenceEntry_s *, NULL, FN_SEQUENCEPICKSENTENCE, pfnSequencePickSentence, pip, (groupName, pickMethod, picked));
 	RETURN_API(sentenceEntry_s *)
 }
 
-static int mm_GetFileSize(char *filename) {
+static FORCE_STACK_ALIGN int mm_GetFileSize(char *filename) {
 	META_ENGINE_HANDLE(int, 0, FN_GETFILESIZE, pfnGetFileSize, p, (filename));
 	RETURN_API(int)
 }
 
-static unsigned int mm_GetApproxWavePlayLen(const char *filepath) {
+static FORCE_STACK_ALIGN unsigned int mm_GetApproxWavePlayLen(const char *filepath) {
 	META_ENGINE_HANDLE(unsigned int, 0, FN_GETAPPROXWAVEPLAYLEN, pfnGetApproxWavePlayLen, p, (filepath));
 	RETURN_API(unsigned int)
 }
 
-static int mm_IsCareerMatch(void) {
+static FORCE_STACK_ALIGN int mm_IsCareerMatch(void) {
 	META_ENGINE_HANDLE(int, 0, FN_ISCAREERMATCH, pfnIsCareerMatch, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
-static int mm_GetLocalizedStringLength(const char *label) {
+static FORCE_STACK_ALIGN int mm_GetLocalizedStringLength(const char *label) {
 	META_ENGINE_HANDLE(int, 0, FN_GETLOCALIZEDSTRINGLENGTH, pfnGetLocalizedStringLength, p, (label));
 	RETURN_API(int)
 }
 
-static void mm_RegisterTutorMessageShown(int mid) {
+static FORCE_STACK_ALIGN void mm_RegisterTutorMessageShown(int mid) {
 	META_ENGINE_HANDLE_void(FN_REGISTERTUTORMESSAGESHOWN, pfnRegisterTutorMessageShown, i, (mid));
 	RETURN_API_void()
 }
 
-static int mm_GetTimesTutorMessageShown(int mid) {
+static FORCE_STACK_ALIGN int mm_GetTimesTutorMessageShown(int mid) {
 	META_ENGINE_HANDLE(int, 0, FN_GETTIMESTUTORMESSAGESHOWN, pfnGetTimesTutorMessageShown, i, (mid));
 	RETURN_API(int)
 }
 
-static void mm_ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+static FORCE_STACK_ALIGN void mm_ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	META_ENGINE_HANDLE_void(FN_PROCESSTUTORMESSAGEDECAYBUFFER, pfnProcessTutorMessageDecayBuffer, pi, (buffer, bufferLength));
 	RETURN_API_void()
 }
 
-static void mm_ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+static FORCE_STACK_ALIGN void mm_ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	META_ENGINE_HANDLE_void(FN_CONSTRUCTTUTORMESSAGEDECAYBUFFER, pfnConstructTutorMessageDecayBuffer, pi, (buffer, bufferLength));
 	RETURN_API_void()
 }
 
-static void mm_ResetTutorMessageDecayData(void) {
+static FORCE_STACK_ALIGN void mm_ResetTutorMessageDecayData(void) {
 	META_ENGINE_HANDLE_void(FN_RESETTUTORMESSAGEDECAYDATA, pfnResetTutorMessageDecayData, void, (VOID_ARG));
 	RETURN_API_void()
 }
 
 // Added 2005/08/11 (no SDK update):
-static void mm_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
+static FORCE_STACK_ALIGN void mm_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
 	static mBOOL s_check = mFALSE;
 	
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.
@@ -890,7 +890,7 @@ static void mm_QueryClientCvarValue(const edict_t *player, const char *cvarName)
 }
 
 // Added 2005/11/21 (no SDK update):
-static void mm_QueryClientCvarValue2(const edict_t *player, const char *cvarName, int requestID) {
+static FORCE_STACK_ALIGN void mm_QueryClientCvarValue2(const edict_t *player, const char *cvarName, int requestID) {
 	static mBOOL s_check = mFALSE;
 	
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.
@@ -905,7 +905,7 @@ static void mm_QueryClientCvarValue2(const edict_t *player, const char *cvarName
 }
 
 // Added 2009/06/19 (no SDK update):
-static int mm_EngCheckParm(const char *pchCmdLineToken, char **pchNextVal) {
+static FORCE_STACK_ALIGN int mm_EngCheckParm(const char *pchCmdLineToken, char **pchNextVal) {
 	static mBOOL s_check = mFALSE;
 
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.

--- a/metamod/h_export.cpp
+++ b/metamod/h_export.cpp
@@ -83,7 +83,7 @@ engine_t Engine;
 // This appears to be the _first_ DLL routine called by the engine, so this
 // is where we hook to load all the other DLLs (game, plugins, etc), which
 // is actually all done in meta_startup().
-C_DLLEXPORT void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine, 
+C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine,
 		globalvars_t *pGlobals)
 {
 #ifdef __linux__

--- a/metamod/linkent.h
+++ b/metamod/linkent.h
@@ -74,8 +74,8 @@ typedef void (*ENTITY_FN) (entvars_t *);
 //  - (plugin loaded) if func still not found, set missing, return
 //  - (plugin loaded, func found) call func
 #define LINK_ENTITY_TO_PLUGIN(entityName, pluginName) \
-	C_DLLEXPORT void entityName(entvars_t *pev); \
-	void entityName(entvars_t *pev) { \
+	C_DLLEXPORT FORCE_STACK_ALIGN void entityName(entvars_t *pev); \
+	FORCE_STACK_ALIGN void entityName(entvars_t *pev) { \
 		static ENTITY_FN pfnEntity = NULL; \
 		static int missing=0; \
 		const char *entStr; \

--- a/metamod/mutil.cpp
+++ b/metamod/mutil.cpp
@@ -58,7 +58,7 @@ static hudtextparms_t default_csay_tparms = {
 };
 
 // Log to console; newline added.
-static void mutil_LogConsole(plid_t /* plid */, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_LogConsole(plid_t /* plid */, const char *fmt, ...) {
 	va_list ap;
 	char buf[MAX_LOGMSG_LEN];
 	unsigned int len;
@@ -77,7 +77,7 @@ static void mutil_LogConsole(plid_t /* plid */, const char *fmt, ...) {
 }
 
 // Log regular message to logs; newline added.
-static void mutil_LogMessage(plid_t plid, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_LogMessage(plid_t plid, const char *fmt, ...) {
 	va_list ap;
 	char buf[MAX_LOGMSG_LEN];
 	plugin_info_t *plinfo;
@@ -90,7 +90,7 @@ static void mutil_LogMessage(plid_t plid, const char *fmt, ...) {
 }
 
 // Log an error message to logs; newline added.
-static void mutil_LogError(plid_t plid, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_LogError(plid_t plid, const char *fmt, ...) {
 	va_list ap;
 	char buf[MAX_LOGMSG_LEN];
 	plugin_info_t *plinfo;
@@ -103,7 +103,7 @@ static void mutil_LogError(plid_t plid, const char *fmt, ...) {
 }
 
 // Log a message only if cvar "developer" set; newline added.
-static void mutil_LogDeveloper(plid_t plid, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_LogDeveloper(plid_t plid, const char *fmt, ...) {
 	va_list ap;
 	char buf[MAX_LOGMSG_LEN];
 	plugin_info_t *plinfo;
@@ -120,7 +120,7 @@ static void mutil_LogDeveloper(plid_t plid, const char *fmt, ...) {
 
 // Print a center-message, with text parameters and varargs.  Provides
 // functionality to the above center_say interfaces.
-static void mutil_CenterSayVarargs(plid_t plid, hudtextparms_t tparms, 
+static FORCE_STACK_ALIGN void mutil_CenterSayVarargs(plid_t plid, hudtextparms_t tparms, 
 		const char *fmt, va_list ap) 
 {
 	char buf[MAX_LOGMSG_LEN];
@@ -138,7 +138,7 @@ static void mutil_CenterSayVarargs(plid_t plid, hudtextparms_t tparms,
 
 // Print message on center of all player's screens.  Uses default text
 // parameters (color green, 10 second fade-in).
-static void mutil_CenterSay(plid_t plid, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_CenterSay(plid_t plid, const char *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);
 	mutil_CenterSayVarargs(plid, default_csay_tparms, fmt, ap);
@@ -146,7 +146,7 @@ static void mutil_CenterSay(plid_t plid, const char *fmt, ...) {
 }
 
 // Print a center-message, with given text parameters.
-static void mutil_CenterSayParms(plid_t plid, hudtextparms_t tparms, const char *fmt, ...) {
+static FORCE_STACK_ALIGN void mutil_CenterSayParms(plid_t plid, hudtextparms_t tparms, const char *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);
 	mutil_CenterSayVarargs(plid, tparms, fmt, ap);
@@ -156,7 +156,7 @@ static void mutil_CenterSayParms(plid_t plid, hudtextparms_t tparms, const char 
 // Allow plugins to call the entity functions in the GameDLL.  In
 // particular, calling "player()" as needed by most Bots.  Suggested by
 // Jussi Kivilinna.
-static qboolean mutil_CallGameEntity(plid_t plid, const char *entStr, entvars_t *pev) {
+static FORCE_STACK_ALIGN qboolean mutil_CallGameEntity(plid_t plid, const char *entStr, entvars_t *pev) {
 	plugin_info_t *plinfo;
 	ENTITY_FN pfnEntity;
 
@@ -176,7 +176,7 @@ static qboolean mutil_CallGameEntity(plid_t plid, const char *entStr, entvars_t 
 
 // Find a usermsg, registered by the gamedll, with the corresponding
 // msgname, and return remaining info about it (msgid, size).
-static int mutil_GetUserMsgID(plid_t plid, const char *msgname, int *size) {
+static FORCE_STACK_ALIGN int mutil_GetUserMsgID(plid_t plid, const char *msgname, int *size) {
 	plugin_info_t *plinfo;
 	MRegMsg *umsg;
 
@@ -195,7 +195,7 @@ static int mutil_GetUserMsgID(plid_t plid, const char *msgname, int *size) {
 
 // Find a usermsg, registered by the gamedll, with the corresponding
 // msgid, and return remaining info about it (msgname, size).
-static const char *mutil_GetUserMsgName(plid_t plid, int msgid, int *size) {
+static FORCE_STACK_ALIGN const char *mutil_GetUserMsgName(plid_t plid, int msgid, int *size) {
 	plugin_info_t *plinfo;
 	MRegMsg *umsg;
 
@@ -239,7 +239,7 @@ static const char *mutil_GetUserMsgName(plid_t plid, int msgid, int *size) {
 }
 
 // Return the full path of the plugin's loaded dll/so file.
-static const char *mutil_GetPluginPath(plid_t plid) {
+static FORCE_STACK_ALIGN const char *mutil_GetPluginPath(plid_t plid) {
 	static char buf[PATH_MAX];
 	MPlugin *plug;
 
@@ -254,7 +254,7 @@ static const char *mutil_GetPluginPath(plid_t plid) {
 }
 
 // Return various string-based info about the game/MOD/gamedll.
-static const char *mutil_GetGameInfo(plid_t plid, ginfo_t type) {
+static FORCE_STACK_ALIGN const char *mutil_GetGameInfo(plid_t plid, ginfo_t type) {
 	static char buf[MAX_STRBUF_LEN];
 	const char *cp;
 	switch(type) {
@@ -285,7 +285,7 @@ static const char *mutil_GetGameInfo(plid_t plid, ginfo_t type) {
 	return(buf);
 }
 
-static int mutil_LoadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME now, void **plugin_handle)
+static FORCE_STACK_ALIGN int mutil_LoadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME now, void **plugin_handle)
 {
 	MPlugin *pl_loaded;
 	
@@ -305,7 +305,7 @@ static int mutil_LoadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME no
 	}
 }
 
-static int mutil_UnloadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
+static FORCE_STACK_ALIGN int mutil_UnloadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
 {
 	MPlugin *findp = NULL;
 	int pindex;
@@ -332,7 +332,7 @@ static int mutil_UnloadMetaPlugin(plid_t plid, const char *fname, PLUG_LOADTIME 
 	return(meta_errno);
 }
 
-static int mutil_UnloadMetaPluginByHandle(plid_t plid, void *plugin_handle, PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
+static FORCE_STACK_ALIGN int mutil_UnloadMetaPluginByHandle(plid_t plid, void *plugin_handle, PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
 {
 	MPlugin *findp;
 
@@ -352,17 +352,17 @@ static int mutil_UnloadMetaPluginByHandle(plid_t plid, void *plugin_handle, PLUG
 }
 
 // Check if player is being queried for cvar
-static const char * mutil_IsQueryingClientCvar(plid_t /*plid*/, const edict_t *player) {
+static FORCE_STACK_ALIGN const char * mutil_IsQueryingClientCvar(plid_t /*plid*/, const edict_t *player) {
 	return(g_Players.is_querying_cvar(player));
 }
 
 //
-static int mutil_MakeRequestID(plid_t /*plid*/) {
+static FORCE_STACK_ALIGN int mutil_MakeRequestID(plid_t /*plid*/) {
 	return(abs(0xbeef<<16) + (++requestid_counter));
 }
 
 //
-static void mutil_GetHookTables(plid_t plid, enginefuncs_t **peng, DLL_FUNCTIONS **pdll, NEW_DLL_FUNCTIONS **pnewdll) {
+static FORCE_STACK_ALIGN void mutil_GetHookTables(plid_t plid, enginefuncs_t **peng, DLL_FUNCTIONS **pdll, NEW_DLL_FUNCTIONS **pnewdll) {
 	if (peng)
 		*peng = &meta_engfuncs;
 	if (pdll)

--- a/metamod/osdep_linkent_linux.cpp
+++ b/metamod/osdep_linkent_linux.cpp
@@ -113,7 +113,7 @@ inline void DLLINTERNAL reset_dlsym_hook(void)
 //
 // Replacement dlsym function
 //
-static void * __replacement_dlsym(void * module, const char * funcname)
+static FORCE_STACK_ALIGN void * __replacement_dlsym(void * module, const char * funcname)
 {
 	//these are needed in case dlsym calls dlsym, default one doesn't do
 	//it but some LD_PRELOADed library that hooks dlsym might actually

--- a/metamod/reg_support.cpp
+++ b/metamod/reg_support.cpp
@@ -92,7 +92,7 @@
 // Generic command handler, passed to the engine for any AddServerCommand
 // calls made by the plugin.  It finds the appropriate plugin function
 // pointer to call based on CMD_ARGV(0).
-void DLLHIDDEN meta_command_handler(void) {
+FORCE_STACK_ALIGN void DLLHIDDEN meta_command_handler(void) {
 	MRegCmd *icmd;
 	const char *cmd;
 
@@ -122,7 +122,7 @@ void DLLHIDDEN meta_command_handler(void) {
 // The string handed to the engine is just a strdup() of the plugin's
 // string.  The function pointer handed to the engine is actually a pointer
 // to a generic command-handler function (see above).
-void DLLHIDDEN meta_AddServerCommand(char *cmd_name, void (*function) (void)) {
+FORCE_STACK_ALIGN void DLLHIDDEN meta_AddServerCommand(char *cmd_name, void (*function) (void)) {
 	MPlugin *iplug=NULL; 
 	MRegCmd *icmd=NULL;
 
@@ -171,7 +171,7 @@ void DLLHIDDEN meta_AddServerCommand(char *cmd_name, void (*function) (void)) {
 // values via the engine functions, this will work fine.  If the plugin
 // code tries to _directly_ read/set the fields of its own cvar structures,
 // it will fail to work properly.
-void DLLHIDDEN meta_CVarRegister(cvar_t *pCvar) {
+FORCE_STACK_ALIGN void DLLHIDDEN meta_CVarRegister(cvar_t *pCvar) {
 	MPlugin *iplug=NULL;
 	MRegCvar *icvar=NULL;
 
@@ -221,7 +221,7 @@ int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize) {
 
 
 // Intercept and record queries
-void DLLHIDDEN meta_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
+FORCE_STACK_ALIGN void DLLHIDDEN meta_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
 	g_Players.set_player_cvar_query(player, cvarName);
 
 	if(g_engfuncs.pfnQueryClientCvarValue)


### PR DESCRIPTION
## Summary

- Define `FORCE_STACK_ALIGN` macro in `comp_dep.h` that expands to `__attribute__((force_align_arg_pointer))` on GCC i386, empty otherwise
- Remove global `-mincoming-stack-boundary=2` from Makefile `CCOPT_ARCH`
- Apply `FORCE_STACK_ALIGN` to all entry point functions called by engine, gamedll, or plugins:
  - `dllapi.cpp` — all `mm_*` callbacks and `GetEntityAPI`/`GetEntityAPI2`/`GetNewDLLFunctions` exports
  - `engine_api.cpp` — all `mm_*` engine API replacement callbacks
  - `mutil.cpp` — all `mutil_*` meta-utility functions
  - `reg_support.cpp` — `meta_command_handler`, `meta_AddServerCommand`, `meta_CVarRegister`, `meta_QueryClientCvarValue`
  - `h_export.cpp` — `GiveFnptrsToDll`
  - `linkent.h` — `LINK_ENTITY_TO_PLUGIN` macro entity exports
  - `osdep_linkent_linux.cpp` — `__replacement_dlsym` (replaces libc `dlsym` via trampoline)

This avoids unnecessary stack realignment prologues in the majority of internal functions, improving code generation while still ensuring correct 16-byte alignment at all external call boundaries.

Fixes #65