### PR TITLE
Use i686-linux-gnu cross-compiler instead of multilib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,14 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - name: Update package list for i386
-        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
+        run: sudo apt-get -y update && sudo apt-get -y install build-essential gcc-i686-linux-gnu g++-i686-linux-gnu
       - name: Build metamod (debug)
-        run: make -j4 -C metamod CC="gcc -m32"
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc"
       - name: Build metamod (optimized)
-        run: make -j4 -C metamod CC="gcc -m32" OPT=opt
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt
       - name: Build trace_plugin (optimized)
-        run: make -j4 -C trace_plugin CC="gcc -m32" OPT=opt
+        run: make -j4 -C trace_plugin CC="i686-linux-gnu-gcc" OPT=opt
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386
       - name: Install valgrind
         run: sudo apt-get -y install valgrind libc6-dbg:i386
       - name: Run tests
-        run: CXX="g++ -m32" make -j4 -C metamod/tests run
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run
       - name: Run valgrind
-        run: CXX="g++ -m32" make -C metamod/tests valgrind
+        run: CXX="i686-linux-gnu-g++" make -C metamod/tests valgrind
 
   coverage:
     runs-on: ubuntu-24.04
@@ -30,9 +30,9 @@ jobs:
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib lcov valgrind
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 lcov valgrind
       - name: Run coverage
-        run: CXX="g++ -m32" make -C metamod/tests coverage
+        run: CXX="i686-linux-gnu-g++" make -C metamod/tests coverage
       - name: Generate job summary
         run: |
           summary=$(lcov --summary metamod/tests/coverage.info --branch-coverage \

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -118,15 +118,15 @@ GCCMAJ_GT_4 = $(shell [ $(GCCMAJ) -gt 4 ] && echo 1 || echo 0)
 
 ifeq "$(HOST)" "cygwin"
 	ifeq "$(TARGETTYPE)" "amd64"
-		CC=gcc-linux-x86_64
+		CC?=gcc-linux-x86_64
 	else
-		CC=gcc-linux
+		CC?=gcc-linux
 	endif
 else
 	ifeq "$(TARGETTYPE)" "amd64"
-		CC=gcc -m64
+		CC?=gcc -m64
 	else
-		CC=gcc -m32
+		CC?=gcc -m32
 	endif
 endif
 


### PR DESCRIPTION
## Summary

- Change `CC=` to `CC?=` in `metamod/Makefile` so environment variables are respected, enabling cross-compilation with `CC=i686-linux-gnu-gcc make opt`
- Switch CI from `g++-multilib` (`gcc -m32`) to `i686-linux-gnu-gcc`/`g++` cross-compiler toolchain
- Remove unnecessary `dpkg --add-architecture i386` from build workflow (cross-compiler has its own sysroot)

## Test plan

- [x] Local production build: `CC=i686-linux-gnu-gcc make -j16 -C metamod opt` succeeds, output is ELF 32-bit i386
- [x] Local test suite: `CXX=i686-linux-gnu-g++ make -j16 -C metamod/tests run` — all tests pass
- [x] CI: all workflows pass with new cross-compiler packages