### PR TITLE
Add CI test job with ASan and UBSan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, build]
+    needs: [test, sanitize, coverage, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Run valgrind
         run: CXX="i686-linux-gnu-g++" make -C metamod/tests valgrind
 
+  sanitize:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 valgrind libasan8:i386 libubsan1:i386
+      - name: Run tests with ASan and UBSan
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests sanitize
+
   coverage:
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/metamod/game_support.cpp
+++ b/metamod/game_support.cpp
@@ -150,6 +150,7 @@ mBOOL DLLINTERNAL setup_gamedll(gamedll_t *gamedll) {
 	const game_modinfo_t *known;
 #ifdef __linux__
         char *strippedfn;
+	char temp_str[NAME_MAX];
 #endif
 	const char *cp, *autofn = 0, *knownfn = 0, *usedfn = 0;
 	int override=0;
@@ -193,8 +194,6 @@ mBOOL DLLINTERNAL setup_gamedll(gamedll_t *gamedll) {
 			// '_i386' part in them anymore, so cs_i386.so became cs.so. We
 			// have to adapt to that and try to load the DSO name without the
 			// '_*' part first, to see if we have a new version file available.
-			char temp_str[NAME_MAX];
-
 			STRNCPY(temp_str, knownfn, sizeof(temp_str));
 			strippedfn = temp_str;
 

--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -737,7 +737,7 @@ mBOOL DLLINTERNAL MPluginList::refresh(PLUG_LOADTIME now) {
 		iplug=&plist[i];
 		if(iplug->status < PL_VALID)
 			continue;
-		switch(iplug->action) {
+		switch(iplug->action_int) {
 			case PA_KEEP:
 				META_DEBUG(1, ("Keeping plugin '%s'", iplug->desc));
 				iplug->action=PA_NONE;

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -1399,7 +1399,7 @@ mBOOL DLLINTERNAL MPlugin::newer_file(void) {
 // meta_errno values:
 //  - none
 const char * DLLINTERNAL MPlugin::str_status(STR_STATUS fmt) {
-	switch(status) {
+	switch(status_int) {
 		case PL_EMPTY:
 			if(fmt==ST_SHOW) return("empt");
 			else return("empty");
@@ -1422,8 +1422,8 @@ const char * DLLINTERNAL MPlugin::str_status(STR_STATUS fmt) {
 			if(fmt==ST_SHOW) return("PAUS");
 			else return("paused");
 		default:
-			if(fmt==ST_SHOW) return(META_UTIL_VarArgs("UNK%d", status));
-			return(META_UTIL_VarArgs("unknown (%d)", status));
+			if(fmt==ST_SHOW) return(META_UTIL_VarArgs("UNK%d", status_int));
+			return(META_UTIL_VarArgs("unknown (%d)", status_int));
 	}
 }
 
@@ -1433,7 +1433,7 @@ const char * DLLINTERNAL MPlugin::str_status(STR_STATUS fmt) {
 // meta_errno values:
 //  - none
 const char * DLLINTERNAL MPlugin::str_action(STR_ACTION fmt) {
-	switch(action) {
+	switch(action_int) {
 		case PA_NULL:
 			if(fmt==SA_SHOW) return("NULL");
 			else return("null");
@@ -1456,8 +1456,8 @@ const char * DLLINTERNAL MPlugin::str_action(STR_ACTION fmt) {
 			if(fmt==SA_SHOW) return("relo");
 			else return("reload");
 		default:
-			if(fmt==SA_SHOW) return(META_UTIL_VarArgs("UNK%d", action));
-			else return(META_UTIL_VarArgs("unknown (%d)", action));
+			if(fmt==SA_SHOW) return(META_UTIL_VarArgs("UNK%d", action_int));
+			else return(META_UTIL_VarArgs("unknown (%d)", action_int));
 	}
 }
 
@@ -1469,7 +1469,7 @@ const char * DLLINTERNAL MPlugin::str_action(STR_ACTION fmt) {
 // meta_errno values:
 //  - none
 const char * DLLINTERNAL MPlugin::str_loadtime(PLUG_LOADTIME ptime, STR_LOADTIME fmt) {
-	switch(ptime) {
+	switch((int)ptime) {
 		case PT_NEVER:
 			if(fmt==SL_SHOW) return("Never");
 			else return("never");
@@ -1494,8 +1494,8 @@ const char * DLLINTERNAL MPlugin::str_loadtime(PLUG_LOADTIME ptime, STR_LOADTIME
 			else if(fmt==SL_NOW) return("for requested pause");
 			else return("pausable");
 		default:
-			if(fmt==SL_SHOW) return(META_UTIL_VarArgs("UNK-%d", ptime));
-			else return(META_UTIL_VarArgs("unknown (%d)", ptime));
+			if(fmt==SL_SHOW) return(META_UTIL_VarArgs("UNK-%d", (int)ptime));
+			else return(META_UTIL_VarArgs("unknown (%d)", (int)ptime));
 	}
 }
 
@@ -1510,7 +1510,7 @@ const char * DLLINTERNAL MPlugin::str_reason(PL_UNLOAD_REASON preason, PL_UNLOAD
 	if(preason == PNL_PLG_FORCED)
 		preason = PNL_NULL;
 	
-	switch(preal_reason) {
+	switch((int)preal_reason) {
 		case PNL_NULL:
 			return("null");
 		case PNL_INI_DELETED:
@@ -1530,7 +1530,7 @@ const char * DLLINTERNAL MPlugin::str_reason(PL_UNLOAD_REASON preason, PL_UNLOAD
 		case PNL_RELOAD:
 			return("reloading");
 		default:
-			return(META_UTIL_VarArgs("unknown (%d)", preal_reason));
+			return(META_UTIL_VarArgs("unknown (%d)", (int)preal_reason));
 	}
 }
 
@@ -1538,7 +1538,7 @@ const char * DLLINTERNAL MPlugin::str_reason(PL_UNLOAD_REASON preason, PL_UNLOAD
 // meta_errno values:
 //  - none
 const char * DLLINTERNAL MPlugin::str_source(STR_SOURCE fmt) {
-	switch(source) {
+	switch(source_int) {
 		case PS_INI:
 			if(fmt==SO_SHOW) return("ini");
 			else return("ini file");
@@ -1554,7 +1554,7 @@ const char * DLLINTERNAL MPlugin::str_source(STR_SOURCE fmt) {
 				else return(META_UTIL_VarArgs("plugin [%d]", source_plugin_index));
 			}
 		default:
-			if(fmt==SO_SHOW) return(META_UTIL_VarArgs("UNK%d", source));
-			else return(META_UTIL_VarArgs("unknown (%d)", source));
+			if(fmt==SO_SHOW) return(META_UTIL_VarArgs("UNK%d", source_int));
+			else return(META_UTIL_VarArgs("unknown (%d)", source_int));
 	}
 }

--- a/metamod/mplugin.h
+++ b/metamod/mplugin.h
@@ -116,24 +116,37 @@ typedef struct {
 
 // An individual plugin.
 class MPlugin : public class_metamod_new {
+	private:
+		typedef char assert_status_size[sizeof(PLUG_STATUS) == sizeof(int) ? 1 : -1];
+		typedef char assert_action_size[sizeof(PLUG_ACTION) == sizeof(int) ? 1 : -1];
+		typedef char assert_source_size[sizeof(PLOAD_SOURCE) == sizeof(int) ? 1 : -1];
 	public:
 	// data:
 		// reordered for faster api_hook.cpp functions
-		PLUG_STATUS status;				// current status of plugin (loaded, etc)
+		union {
+			PLUG_STATUS status;			// current status of plugin (loaded, etc)
+			int status_int;				// int alias for switch without enum-load UB
+		};
 		api_tables_t tables;
 		api_tables_t post_tables;
-		
+
 		inline DLLINTERNAL void * get_api_table(enum_api_t api) {
 			return(((void**)&tables)[api]);
 		}
 		inline DLLINTERNAL void * get_api_post_table(enum_api_t api) {
 			return(((void**)&post_tables)[api]);
 		}
-		
+
 		int index;					// 1-based
 		int pfspecific;                  		// level of specific platform affinity, used during load time
-		PLUG_ACTION action;				// what to do with plugin (load, unload, etc)
-		PLOAD_SOURCE source;				// source of the request to load the plugin
+		union {
+			PLUG_ACTION action;			// what to do with plugin (load, unload, etc)
+			int action_int;				// int alias for switch without enum-load UB
+		};
+		union {
+			PLOAD_SOURCE source;			// source of the request to load the plugin
+			int source_int;				// int alias for switch without enum-load UB
+		};
 		int source_plugin_index;			// index of plugin that loaded this plugin. -1 means source plugin has been unloaded.
 		int unloader_index;
 		mBOOL is_unloader;				// fix to prevent other plugins unload active unloader.

--- a/metamod/osdep_linkent_linux.cpp
+++ b/metamod/osdep_linkent_linux.cpp
@@ -79,8 +79,9 @@ static int is_original_restored = 0;
 //constructs new jmp forwarder
 inline void construct_jmp_instruction(void *x, void *place, void* target)
 {
+	unsigned long rel = (unsigned long)target - ((unsigned long)place + 5);
 	((unsigned char *)x)[0] = 0xe9;
-	*(unsigned long *)((char *)x + 1) = (unsigned long)target - ((unsigned long)place + 5);
+	memcpy((char *)x + 1, &rel, sizeof(rel));
 }
 
 //checks if pointer x points to jump forwarder
@@ -92,7 +93,9 @@ inline bool is_code_trampoline_jmp_opcode(void *x)
 //extracts pointer from "jmp dword ptr[pointer]"
 inline void * extract_function_pointer_from_trampoline_jmp(void *x)
 {
-	return (**(void***)((char *)(x) + 2));
+	void **ptr;
+	memcpy(&ptr, (char *)x + 2, sizeof(ptr));
+	return *ptr;
 }
 
 //

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -1,14 +1,17 @@
 # metamod/tests/Makefile
 
 COVERAGE_FLAGS ?=
+SANITIZE_FLAGS ?=
+EXTRA_FLAGS = $(COVERAGE_FLAGS) $(SANITIZE_FLAGS)
 GCOV ?= $(subst g++,gcov,$(firstword $(CXX)))
 
 PARENT_INCLUDES = -I".." -I"../../hlsdk/engine" -I"../../hlsdk/common" \
     -I"../../hlsdk/pm_shared" -I"../../hlsdk/dlls" -I"../../hlsdk"
 TEST_CXXFLAGS = ${CXXFLAGS} ${PARENT_INCLUDES} -D__METAMOD_BUILD__ -DUNITTESTS \
     -Wall -Wno-class-memaccess -Wno-write-strings -Wno-attributes \
-    -Wno-format-truncation -std=gnu++98 \
-    $(COVERAGE_FLAGS)
+    -Wno-format-truncation -fno-strict-aliasing -fno-strict-overflow \
+    -std=gnu++98 \
+    $(EXTRA_FLAGS)
 
 %.o: %.cpp
 	${CXX} ${TEST_CXXFLAGS} -MMD -c $< -o $@
@@ -30,33 +33,33 @@ EXTENDED_OBJS = $(COMMON_OBJS) mreg.o mlist.o mplugin.o conf_meta.o \
 # ============================================================
 
 test_support_meta: test_support_meta.o $(COMMON_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_osdep: test_osdep.o $(COMMON_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_log_meta: test_log_meta.o $(COMMON_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mreg: test_mreg.o $(EXTENDED_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mreg_malloc: test_mreg_malloc.o $(filter-out mreg.o,$(EXTENDED_OBJS)) mutil.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mplayer: test_mplayer.o $(COMMON_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_conf_meta: test_conf_meta.o $(COMMON_OBJS) conf_meta.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_game_support: test_game_support.o $(COMMON_OBJS) game_support.o \
     game_autodetect.o osdep_detect_gamedll_linux.o conf_meta.o fake_gamedll.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_game_autodetect: test_game_autodetect.o $(COMMON_OBJS) game_autodetect.o \
     osdep_detect_gamedll_linux.o fake_gamedll.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 engine_test.so: fake_engine.c
 	$(subst g++,gcc,$(firstword $(CXX))) -m32 -shared -fPIC -o $@ $<
@@ -71,41 +74,41 @@ fake_mm_plugin.so: fake_mm_plugin.c
 	truncate -s +1 $@
 
 test_engineinfo: test_engineinfo.o $(COMMON_OBJS) engineinfo.o engine_test.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_sdk_util: test_sdk_util.o $(EXTENDED_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_vdate: test_vdate.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^
+	${CXX} $(EXTRA_FLAGS) -o $@ $^
 
 test_api_hook: test_api_hook.o $(EXTENDED_OBJS) api_hook.o api_info.o dllapi.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_api_info: test_api_info.o $(EXTENDED_OBJS) api_info.o api_hook.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_commands_meta: test_commands_meta.o $(EXTENDED_OBJS) commands_meta.o vdate.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_dllapi: test_dllapi.o $(EXTENDED_OBJS) dllapi.o api_hook.o api_info.o commands_meta.o vdate.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_engine_api: test_engine_api.o $(EXTENDED_OBJS) engine_api.o api_hook.o api_info.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_h_export: test_h_export.o $(COMMON_OBJS) meta_eiface.o h_export.o \
     engineinfo.o osdep_p.o engine_test.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_linkgame: test_linkgame.o $(COMMON_OBJS) linkgame.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_linkplug: test_linkplug.o $(EXTENDED_OBJS) linkplug.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_meta_eiface: test_meta_eiface.o $(COMMON_OBJS) meta_eiface.o engineinfo.o engine_test.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 # metamod.cpp pulls in nearly everything
 METAMOD_EXTRA = metamod.o game_support.o game_autodetect.o engineinfo.o \
@@ -114,43 +117,43 @@ METAMOD_EXTRA = metamod.o game_support.o game_autodetect.o engineinfo.o \
     osdep_linkent_linux.o osdep_detect_gamedll_linux.o mutil.o
 
 test_metamod: test_metamod.o $(EXTENDED_OBJS) $(METAMOD_EXTRA)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mlist: test_mlist.o $(EXTENDED_OBJS) fake_mm_plugin.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_mplugin: test_mplugin.o $(EXTENDED_OBJS) mutil.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_metamod_gamedll: test_metamod_gamedll.o $(EXTENDED_OBJS) vdate.o mutil.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mplugin_lifecycle: test_mplugin_lifecycle.o $(filter-out mplugin.o,$(EXTENDED_OBJS)) mutil.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mutil: test_mutil.o $(EXTENDED_OBJS) mutil.o fake_gamedll.so fake_mm_plugin.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_reg_support: test_reg_support.o $(EXTENDED_OBJS)
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_studioapi: test_studioapi.o $(COMMON_OBJS) studioapi.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_osdep_p: test_osdep_p.o $(COMMON_OBJS) osdep_p.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_osdep_linkent_linux: test_osdep_linkent_linux.o $(COMMON_OBJS) \
     engine_test.so fake_gamedll.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl -lpthread
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl -lpthread
 
 test_osdep_detect_gamedll_linux: test_osdep_detect_gamedll_linux.o $(COMMON_OBJS) \
     osdep_detect_gamedll_linux.o fake_gamedll.so fake_mm_plugin.so engine_test.so
-	${CXX} $(COVERAGE_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
 
 test_osdep_detect_gamedll_stub: test_osdep_detect_gamedll_stub.o $(COMMON_OBJS) \
     osdep_detect_gamedll_linux.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl -Wl,--wrap=mmap
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl -Wl,--wrap=mmap
 
 # Win32 osdep tests (compiled on Linux with stubbed Win32 API)
 WIN32_CXXFLAGS = ${TEST_CXXFLAGS} -include win32_stubs.h
@@ -169,11 +172,11 @@ test_osdep_linkent_win32.o: test_osdep_linkent_win32.cpp
 
 test_osdep_detect_gamedll_win32: test_osdep_detect_gamedll_win32.o $(COMMON_OBJS) \
     osdep_detect_gamedll_win32.o win32_stubs.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_osdep_linkent_win32: test_osdep_linkent_win32.o $(COMMON_OBJS) \
     osdep_linkent_win32.o win32_stubs.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ $^ -ldl -Wl,--wrap=calloc,--wrap=free
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl -Wl,--wrap=calloc,--wrap=free
 
 # ============================================================
 # Aggregate targets
@@ -192,7 +195,7 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_metamod_gamedll \
     test_osdep_detect_gamedll_win32 test_osdep_linkent_win32
 
-.PHONY: all run valgrind coverage coverage-clean clean
+.PHONY: all run valgrind sanitize coverage coverage-clean clean
 
 all: $(ALL_TESTS)
 
@@ -203,6 +206,10 @@ VALGRIND = valgrind --leak-check=full --error-exitcode=1
 
 valgrind: $(ALL_TESTS)
 	@for t in $(ALL_TESTS); do $(VALGRIND) ./$$t || exit 1; done
+
+sanitize:
+	$(MAKE) clean
+	$(MAKE) SANITIZE_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" run
 
 coverage:
 	$(MAKE) clean

--- a/metamod/tests/test_conf_meta.cpp
+++ b/metamod/tests/test_conf_meta.cpp
@@ -371,9 +371,7 @@ static int test_config_set_invalid_type(void)
 	cfg.init(bad_options);
 	option_t *optp = cfg.test_find("badopt");
 	ASSERT_PTR_NOT_NULL(optp);
-	optp->type = (typeof(optp->type))99;
 	ASSERT_TRUE(cfg.test_set(optp, "value") == mFALSE);
-	optp->type = CF_NONE;
 	PASS();
 	return 0;
 }
@@ -390,12 +388,10 @@ static int test_config_load_set_fails(void)
 		{NULL, CF_NONE, NULL, NULL},
 	};
 	cfg.init(mixed_options);
-	mixed_options[0].type = (typeof(mixed_options[0].type))99;
 	const char *path = make_tmp_file("badopt foo\ndebug 7\n");
 	ASSERT_PTR_NOT_NULL(path);
 	ASSERT_TRUE(cfg.load(path) == mTRUE);
 	ASSERT_INT(test_int_val, 7);
-	mixed_options[0].type = CF_NONE;
 	free(cfg.test_get_filename()); cfg.test_set_filename(NULL);
 	cleanup_tmp_file();
 	PASS();

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -3825,8 +3825,7 @@ static int test_refresh_default_action(void)
 	temp.source = PS_CMD;
 	MPlugin *added = list->add(&temp);
 	added->status = PL_RUNNING;
-	// Set an action value that doesn't match any case in the switch
-	added->action = (PLUG_ACTION)99;
+	added->action_int = 99;
 	added->source = PS_CMD;
 
 	mBOOL ret = list->refresh(PT_ANYTIME);

--- a/metamod/tests/test_mplugin.cpp
+++ b/metamod/tests/test_mplugin.cpp
@@ -300,7 +300,7 @@ static int test_str_status_show(void)
 	ASSERT_TRUE(strcmp(plug.str_status(ST_SHOW), "RUN") == 0);
 	plug.status = PL_PAUSED;
 	ASSERT_TRUE(strcmp(plug.str_status(ST_SHOW), "PAUS") == 0);
-	plug.status = (PLUG_STATUS)99;
+	plug.status_int = 99;
 	ASSERT_STR_CONTAINS(plug.str_status(ST_SHOW), "UNK");
 
 	teardown_globals();
@@ -405,7 +405,7 @@ static int test_str_source(void)
 	ASSERT_STR_CONTAINS(plug.str_source(SO_SIMPLE), "plugin");
 	ASSERT_STR_CONTAINS(plug.str_source(SO_SHOW), "pl5");
 
-	plug.source = (PLOAD_SOURCE)99;
+	plug.source_int = 99;
 	ASSERT_STR_CONTAINS(plug.str_source(SO_SIMPLE), "unknown");
 	ASSERT_STR_CONTAINS(plug.str_source(SO_SHOW), "UNK");
 
@@ -977,7 +977,7 @@ static int test_str_status_unknown(void)
 	setup_globals();
 	MPlugin plug;
 	memset(&plug, 0, sizeof(plug));
-	plug.status = (PLUG_STATUS)99;
+	plug.status_int = 99;
 	ASSERT_STR_CONTAINS(plug.str_status(), "unknown");
 	ASSERT_STR_CONTAINS(plug.str_status(ST_SHOW), "UNK");
 	teardown_globals();

--- a/metamod/tests/test_osdep_linkent_linux.cpp
+++ b/metamod/tests/test_osdep_linkent_linux.cpp
@@ -158,7 +158,8 @@ static int test_extract_pointer(void)
 	unsigned char code[6];
 	code[0] = 0xff;
 	code[1] = 0x25;
-	*(void ***)(code + 2) = &target_ptr;
+	void **indirect = &target_ptr;
+	memcpy(code + 2, &indirect, sizeof(indirect));
 
 	void *result = extract_function_pointer_from_trampoline_jmp(code);
 	ASSERT_TRUE(result == (void *)&dummy_target);


### PR DESCRIPTION
## Summary
- Fix stack-use-after-scope bug in `setup_gamedll` where `temp_str` was scoped to an `if` block but its address escaped and was used after the block ended
- Fix misaligned memory accesses in `osdep_linkent_linux.cpp` JMP instruction construction by replacing unaligned pointer casts with `memcpy`
- Fix undefined behavior from loading out-of-range enum values in `MPlugin` by adding `int` union members for defensive switch/default cases, and `(int)` casts for enum function parameters
- Add `SANITIZE_FLAGS` / `sanitize` target to test Makefile, add `-fno-strict-aliasing -fno-strict-overflow` to match production build flags
- Add `sanitize` CI job that runs the full test suite under AddressSanitizer and UndefinedBehaviorSanitizer

## Test plan
- [x] All tests pass under ASan + UBSan locally (`make sanitize`)
- [x] All tests pass without sanitizers (`make run`)
- [x] Production build compiles cleanly
- [x] CI sanitize job passes