### PR TITLE
Fix bugs found by unit tests (#68, #69, #70, #71, #72)

### DIFF
--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -847,6 +847,8 @@ mBOOL DLLINTERNAL MPlugin::attach(PLUG_LOADTIME now) {
 	}
 	if(!(pfn_attach = (META_ATTACH_FN) DLSYM(handle, "Meta_Attach"))) {
 		META_WARNING("dll: Failed attach plugin '%s': Couldn't find Meta_Attach(): %s", desc, DLERROR());
+		free(gamedll_funcs.dllapi_table); gamedll_funcs.dllapi_table=NULL;
+		free(gamedll_funcs.newapi_table); gamedll_funcs.newapi_table=NULL;
 		// caller will dlclose()
 		RETURN_ERRNO(mFALSE, ME_DLMISSING);
 	}
@@ -857,6 +859,8 @@ mBOOL DLLINTERNAL MPlugin::attach(PLUG_LOADTIME now) {
 	ret=pfn_attach(now, &meta_table, &PublicMetaGlobals, &gamedll_funcs);
 	if(ret != TRUE) {
 		META_WARNING("dll: Failed attach plugin '%s': Error from Meta_Attach(): %d", desc, ret);
+		free(gamedll_funcs.dllapi_table); gamedll_funcs.dllapi_table=NULL;
+		free(gamedll_funcs.newapi_table); gamedll_funcs.newapi_table=NULL;
 		// caller will dlclose()
 		RETURN_ERRNO(mFALSE, ME_DLERROR);
 	}

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -65,34 +65,39 @@ mBOOL DLLINTERNAL MPlugin::ini_parseline(const char *line) {
 	char *tmp_line;
 
 	//
-	tmp_line=strdup(line);
-	if(!tmp_line)
+	char *tmp_alloc;
+	tmp_alloc=strdup(line);
+	if(!tmp_alloc)
 		RETURN_ERRNO(mFALSE, ME_NOMEM);
+	tmp_line=tmp_alloc;
 
 	// skip whitespace at start of line
 	while(*tmp_line==' ' || *tmp_line=='\t') tmp_line++;
 
 	// remove whitespace at end of line
-	cp = tmp_line + strlen(tmp_line) -1;
-	while(*cp==' ' || *cp=='\t') *cp--='\0';
+	int len = strlen(tmp_line);
+	if(len > 0) {
+		cp = tmp_line + len - 1;
+		while(cp >= tmp_line && (*cp==' ' || *cp=='\t')) *cp--='\0';
+	}
 
 	// skip empty lines
 	if(tmp_line[0]=='\0') {
 		META_DEBUG(7, ("ini: Ignoring empty line: %s", tmp_line));
-		free(tmp_line);
+		free(tmp_alloc);
 		RETURN_ERRNO(mFALSE, ME_BLANK);
 	}
 
 	if(tmp_line[0]=='#' || tmp_line[0]==';' || strstr(tmp_line, "//")==tmp_line) {
 		META_DEBUG(7, ("ini: Ignoring commented line: %s", tmp_line));
-		free(tmp_line);
+		free(tmp_alloc);
 		RETURN_ERRNO(mFALSE, ME_COMMENT);
 	}
 	
 	// grab platform ("win32" or "linux")
 	token=strtok_r(tmp_line, " \t", &ptr_token);
 	if(!token) {
-		free(tmp_line);
+		free(tmp_alloc);
 		RETURN_ERRNO(mFALSE, ME_FORMAT);
 	}
 	if(strcasecmp(token, PLATFORM) == 0) {
@@ -102,14 +107,14 @@ mBOOL DLLINTERNAL MPlugin::ini_parseline(const char *line) {
 	} else {
 		// plugin is not for this OS
 		META_DEBUG(7, ("ini: Ignoring entry for %s", token));
-		free(tmp_line);
+		free(tmp_alloc);
 		RETURN_ERRNO(mFALSE, ME_OSNOTSUP);
 	}
 
 	// grab filename
 	token=strtok_r(NULL, " \t\r\n", &ptr_token);
 	if(!token) {
-		free(tmp_line);
+		free(tmp_alloc);
 		RETURN_ERRNO(mFALSE, ME_FORMAT);
 	}
 	STRNCPY(filename, token, sizeof(filename));
@@ -141,7 +146,7 @@ mBOOL DLLINTERNAL MPlugin::ini_parseline(const char *line) {
 	source=PS_INI;
 	status=PL_VALID;
 	
-	free(tmp_line);
+	free(tmp_alloc);
 	return(mTRUE);
 }
 

--- a/metamod/mreg.cpp
+++ b/metamod/mreg.cpp
@@ -332,8 +332,10 @@ MRegCvar * DLLINTERNAL MRegCvarList::add(const char *addname) {
 	}
 	icvar->data->name=strdup(addname);
 	if(!icvar->data->name) {
-		META_WARNING("Couldn't strdup for adding reg cvar name '%s': %s", 
+		META_WARNING("Couldn't strdup for adding reg cvar name '%s': %s",
 				addname, strerror(errno));
+		free(icvar->data);
+		icvar->data = NULL;
 		RETURN_ERRNO(NULL, ME_NOMEM);
 	}
 	endlist++;

--- a/metamod/osdep_detect_gamedll_linux.cpp
+++ b/metamod/osdep_detect_gamedll_linux.cpp
@@ -70,8 +70,8 @@ static void signal_handler_sigsegv(int) {
 	longjmp(signal_jmp_buf, 1);
 }
 
-#define invalid_elf_ptr(x) (((unsigned long)&(x)) > file_end - 1)
-#define invalid_elf_offset(x) (((unsigned long)(x)) > filesize - 1)
+#define invalid_elf_ptr(x) (((unsigned long)&(x)) > file_end)
+#define invalid_elf_offset(x) (((unsigned long)(x)) > filesize)
 #define elf_error_exit() \
 	do { \
 		sigaction(SIGSEGV, &oldaction, 0); \

--- a/metamod/osdep_linkent_linux.cpp
+++ b/metamod/osdep_linkent_linux.cpp
@@ -87,7 +87,7 @@ inline void construct_jmp_instruction(void *x, void *place, void* target)
 //checks if pointer x points to jump forwarder
 inline bool is_code_trampoline_jmp_opcode(void *x)
 {
-	return (((unsigned char *)x)[0] == 0xff || ((unsigned char *)x)[1] == 0x25);
+	return (((unsigned char *)x)[0] == 0xff && ((unsigned char *)x)[1] == 0x25);
 }
 
 //extracts pointer from "jmp dword ptr[pointer]"

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -63,15 +63,12 @@ test_game_autodetect: test_game_autodetect.o $(COMMON_OBJS) game_autodetect.o \
 
 engine_test.so: fake_engine.c
 	$(subst g++,gcc,$(firstword $(CXX))) -m32 -shared -fPIC -o $@ $<
-	truncate -s +1 $@
 
 fake_gamedll.so: fake_gamedll.c
 	$(subst g++,gcc,$(firstword $(CXX))) -m32 -shared -fPIC -o $@ $<
-	truncate -s +1 $@
 
 fake_mm_plugin.so: fake_mm_plugin.c
 	$(subst g++,gcc,$(firstword $(CXX))) -m32 -shared -fPIC -o $@ $<
-	truncate -s +1 $@
 
 test_engineinfo: test_engineinfo.o $(COMMON_OBJS) engineinfo.o engine_test.so
 	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -3873,21 +3873,6 @@ static int test_plugin_addload_attach_fails(void)
 	MPlugin *p = listp->plugin_addload((plid_t)&loader_info, "dlls/pa_attfail.so", PT_ANYTIME);
 	ASSERT_TRUE(p == NULL);
 
-	// Production bug: attach() allocates gamedll_funcs tables before
-	// calling Meta_Attach; when Meta_Attach fails, they leak.
-	// Clean up manually for valgrind.
-	for (int i = 0; i < listp->endlist; i++) {
-		MPlugin &mp = listp->plist[i];
-		if (mp.test_gamedll_funcs().dllapi_table) {
-			free(mp.test_gamedll_funcs().dllapi_table);
-			mp.test_gamedll_funcs().dllapi_table = NULL;
-		}
-		if (mp.test_gamedll_funcs().newapi_table) {
-			free(mp.test_gamedll_funcs().newapi_table);
-			mp.test_gamedll_funcs().newapi_table = NULL;
-		}
-	}
-
 	unsetenv("FAKE_MM_ATTACH_FAIL");
 	unlink("/tmp/test_mlist_gd/dlls/pa_attfail.so");
 	Plugins = NULL;
@@ -3916,19 +3901,6 @@ static int test_cmd_addload_attach_fails(void)
 
 	mBOOL ret = listp->cmd_addload("dlls/cmd_attfail.so");
 	ASSERT_TRUE(ret == mFALSE);
-
-	// Clean up leaked gamedll_funcs tables (production bug)
-	for (int i = 0; i < listp->endlist; i++) {
-		MPlugin &mp = listp->plist[i];
-		if (mp.test_gamedll_funcs().dllapi_table) {
-			free(mp.test_gamedll_funcs().dllapi_table);
-			mp.test_gamedll_funcs().dllapi_table = NULL;
-		}
-		if (mp.test_gamedll_funcs().newapi_table) {
-			free(mp.test_gamedll_funcs().newapi_table);
-			mp.test_gamedll_funcs().newapi_table = NULL;
-		}
-	}
 
 	unsetenv("FAKE_MM_ATTACH_FAIL");
 	unlink("/tmp/test_mlist_gd/dlls/cmd_attfail.so");

--- a/metamod/tests/test_mplugin.cpp
+++ b/metamod/tests/test_mplugin.cpp
@@ -953,10 +953,6 @@ static int test_str_loadable_with_info(void)
 	return 0;
 }
 
-// NOTE: ini_parseline has a bug with whitespace-only lines:
-// strdup + pointer advance + free(advanced_ptr) = invalid free.
-// Skip testing that path to avoid crashing.
-
 static int test_ini_parseline_no_path_separator(void)
 {
 	TEST("ini_parseline - filename without path sets file=filename");
@@ -1347,12 +1343,6 @@ static int test_free_api_pointers_null(void)
 // ini_parseline edge cases
 // ============================================================
 
-// BUG: ini_parseline has a production bug where it advances tmp_line past
-// leading whitespace, then calls free() on the advanced pointer instead of
-// the original strdup result. Also, the trailing-whitespace removal loop
-// underflows when strlen==0 (cp = tmp_line + 0 - 1). Both are UB/crash.
-// Uncomment when the production code is fixed.
-#if 0
 static int test_ini_parseline_empty_line(void)
 {
 	TEST("ini_parseline - empty line returns ME_BLANK");
@@ -1366,7 +1356,6 @@ static int test_ini_parseline_empty_line(void)
 	PASS();
 	return 0;
 }
-#endif
 
 // ============================================================
 // check_input — empty filename[0] but valid file pointer (lines 243-246)
@@ -1712,6 +1701,7 @@ int main(void)
 	fail |= test_ini_parseline_no_filename();
 	fail |= test_ini_parseline_no_description();
 	fail |= test_ini_parseline_no_path_separator();
+	fail |= test_ini_parseline_empty_line();
 
 	// cmd_parseline
 	fail |= test_cmd_parseline_valid();

--- a/metamod/tests/test_mreg_malloc.cpp
+++ b/metamod/tests/test_mreg_malloc.cpp
@@ -228,15 +228,11 @@ static int test_regcvarlist_add_strdup_fail(void)
 
 	MRegCvarList list;
 	// Fail on second alloc: calloc succeeds, strdup fails.
-	// BUG: production code leaks the calloc'd cvar_t when strdup fails
-	// (mreg.cpp line 337 returns without freeing icvar->data).
 	mock_alloc_fail_after(1);
 	MRegCvar *result = list.add("strdup_fail_cvar");
 	ASSERT_PTR_NULL(result);
 	ASSERT_TRUE(meta_errno == ME_NOMEM);
-	// Clean up the leaked cvar_t to satisfy valgrind
-	free(list.test_vlist()[list.test_endlist()].data);
-	list.test_vlist()[list.test_endlist()].data = NULL;
+	ASSERT_PTR_NULL(list.test_vlist()[list.test_endlist()].data);
 
 	mock_alloc_reset();
 	PASS();
@@ -287,14 +283,11 @@ static int test_regcvarlist_add_grow_strdup_fail(void)
 		ASSERT_PTR_NOT_NULL(list.add(name));
 	}
 	// Growth path: realloc(1) succeeds, calloc(2) succeeds, strdup(3) fails.
-	// BUG: production code leaks the calloc'd cvar_t (same as above).
 	mock_alloc_fail_after(2);
 	MRegCvar *result = list.add("grow_strdup_fail");
 	ASSERT_PTR_NULL(result);
 	ASSERT_TRUE(meta_errno == ME_NOMEM);
-	// Clean up the leaked cvar_t
-	free(list.test_vlist()[list.test_endlist()].data);
-	list.test_vlist()[list.test_endlist()].data = NULL;
+	ASSERT_PTR_NULL(list.test_vlist()[list.test_endlist()].data);
 
 	mock_alloc_reset();
 	PASS();

--- a/metamod/tests/test_osdep_linkent_linux.cpp
+++ b/metamod/tests/test_osdep_linkent_linux.cpp
@@ -120,18 +120,18 @@ static int test_trampoline_not_ff25(void)
 
 static int test_trampoline_only_ff(void)
 {
-	TEST("is_code_trampoline_jmp_opcode - FF without 25 (bug: || returns true)");
+	TEST("is_code_trampoline_jmp_opcode - FF without 25 returns false");
 	unsigned char code[] = { 0xff, 0x00, 0x00, 0x00, 0x00, 0x00 };
-	ASSERT_TRUE(is_code_trampoline_jmp_opcode(code) == true);
+	ASSERT_TRUE(is_code_trampoline_jmp_opcode(code) == false);
 	PASS();
 	return 0;
 }
 
 static int test_trampoline_only_25(void)
 {
-	TEST("is_code_trampoline_jmp_opcode - 25 at byte[1] without FF (bug: || returns true)");
+	TEST("is_code_trampoline_jmp_opcode - 25 at byte[1] without FF returns false");
 	unsigned char code[] = { 0x00, 0x25, 0x00, 0x00, 0x00, 0x00 };
-	ASSERT_TRUE(is_code_trampoline_jmp_opcode(code) == true);
+	ASSERT_TRUE(is_code_trampoline_jmp_opcode(code) == false);
 	PASS();
 	return 0;
 }


### PR DESCRIPTION
## Summary

- Fix `is_code_trampoline_jmp_opcode()` using `||` instead of `&&`, causing any `0xff` or `0x25` byte to match (#68)
- Fix `MRegCvarList::add()` leaking `cvar_t` allocation when `strdup` fails (#69)
- Fix `attach()` leaking `gamedll_funcs` tables when `Meta_Attach` fails or DLSYM paths are missing (#70)
- Fix `ini_parseline()` calling `free()` on advanced `strdup` pointer and buffer underflow on empty lines (#71)
- Fix `is_gamedll()` off-by-one in ELF bounds check macros allowing one-byte-past-end access (#72)

## Test plan

- [x] All unit tests pass (`make run`)
- [x] All tests pass under ASan+UBSan (`make sanitize`)
- [x] All tests pass under Valgrind (`make valgrind`)
- [ ] CI passes