### PR TITLE
Add missing FORCE_STACK_ALIGN to engine/plugin-facing functions

### DIFF
--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -428,7 +428,7 @@ DLL_FUNCTIONS *g_pHookedDllFunctions = &gFunctionTable;
 // It's unclear whether a DLL coded under SDK2 needs to provide the older
 // GetAPI or not..
 
-C_DLLEXPORT int GetEntityAPI(DLL_FUNCTIONS *pFunctionTable, int interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI(DLL_FUNCTIONS *pFunctionTable, int interfaceVersion)
 {
 	META_DEBUG(3, ("called: GetEntityAPI; version=%d", interfaceVersion));
 	if(!pFunctionTable || metamod_not_loaded) {
@@ -443,7 +443,7 @@ C_DLLEXPORT int GetEntityAPI(DLL_FUNCTIONS *pFunctionTable, int interfaceVersion
 	return(TRUE);
 }
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
 {
 	META_DEBUG(3, ("called: GetEntityAPI2; version=%d", *interfaceVersion));
 	if(!pFunctionTable || metamod_not_loaded) {
@@ -484,7 +484,7 @@ static meta_new_dll_functions_t sNewFunctionTable(
 
 NEW_DLL_FUNCTIONS *g_pHookedNewDllFunctions = &sNewFunctionTable;
 
-C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion) 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion)
 {
 	META_DEBUG(6, ("called: GetNewDLLFunctions; version=%d", *interfaceVersion));
 #if 0 // ~dvander - but then you can't use cvar querying on many mods...

--- a/metamod/dllapi.h
+++ b/metamod/dllapi.h
@@ -47,12 +47,12 @@ typedef int (*GETENTITYAPI2_FN) (DLL_FUNCTIONS *pFunctionTable, int *interfaceVe
 typedef int (*GETNEWDLLFUNCTIONS_FN) (NEW_DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion);
 
 // From SDK dlls/cbase.h:
-C_DLLEXPORT int GetEntityAPI( DLL_FUNCTIONS *pFunctionTable, int interfaceVersion );
-C_DLLEXPORT int GetEntityAPI2( DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion );
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI( DLL_FUNCTIONS *pFunctionTable, int interfaceVersion );
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2( DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion );
 
 // No example in SDK..
 // From Adminmod dll.cpp:
-C_DLLEXPORT int GetNewDLLFunctions( NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion );
+C_DLLEXPORT FORCE_STACK_ALIGN int GetNewDLLFunctions( NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion );
 
 // Typedefs for the above functions:
 

--- a/metamod/reg_support.cpp
+++ b/metamod/reg_support.cpp
@@ -215,7 +215,7 @@ FORCE_STACK_ALIGN void DLLHIDDEN meta_CVarRegister(cvar_t *pCvar) {
 
 
 // Replacement for engine routine RegUserMsg; called by plugins. 
-int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize) {
+FORCE_STACK_ALIGN int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize) {
 	return(REG_USER_MSG(strdup(pszName), iSize));
 }
 

--- a/metamod/reg_support.h
+++ b/metamod/reg_support.h
@@ -43,7 +43,7 @@
 void DLLHIDDEN meta_command_handler(void);
 void DLLHIDDEN meta_AddServerCommand(char *cmd_name, REG_CMD_FN function);
 void DLLHIDDEN meta_CVarRegister(cvar_t *pCvar);
-int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize);
+FORCE_STACK_ALIGN int DLLHIDDEN meta_RegUserMsg(const char *pszName, int iSize);
 void DLLHIDDEN meta_QueryClientCvarValue(const edict_t *player, const char *cvarName);
 
 #endif /* REG_SUPPORT_H */


### PR DESCRIPTION
## Summary
- Add `FORCE_STACK_ALIGN` to `meta_RegUserMsg` (called by plugins via `Engine.pl_funcs->pfnRegUserMsg`)
- Add `FORCE_STACK_ALIGN` to `GetEntityAPI`, `GetEntityAPI2`, and `GetNewDLLFunctions` (resolved by engine via dlsym and called as function pointers)

These functions are called by the engine or plugins and need `force_align_arg_pointer` to guarantee correct stack alignment on i686.

## Test plan
- [x] i686 cross-compile build passes
- [x] Unit tests pass