### PR TITLE
Add FORCE_STACK_ALIGN to example plugins and build all plugins in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
         run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC="i686-linux-gnu-gcc" OPT=opt
+      - name: Build stub_plugin (optimized)
+        run: make -j4 -C stub_plugin CC="i686-linux-gnu-gcc" OPT=opt
+      - name: Build wdmisc_plugin (optimized)
+        run: make -j4 -C wdmisc_plugin CC="i686-linux-gnu-gcc" OPT=opt
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -24,6 +28,8 @@ jobs:
           path: |
             metamod/opt.linux_i386/metamod.so
             trace_plugin/opt.linux_i386/trace_mm.so
+            stub_plugin/opt.linux_i386/stub_mm.so
+            wdmisc_plugin/opt.linux_i386/wdmisc_mm.so
 
   build-linux-bionic:
     runs-on: ubuntu-24.04
@@ -36,7 +42,9 @@ jobs:
             lpenz/ubuntu-bionic-i386 \
             bash -c "apt-get -y update && apt-get -y install build-essential g++ make && \
               make -j4 -C metamod OPT=opt && \
-              make -j4 -C trace_plugin OPT=opt"
+              make -j4 -C trace_plugin OPT=opt && \
+              make -j4 -C stub_plugin OPT=opt && \
+              make -j4 -C wdmisc_plugin OPT=opt"
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -44,6 +52,8 @@ jobs:
           path: |
             metamod/opt.linux_i386/metamod.so
             trace_plugin/opt.linux_i386/trace_mm.so
+            stub_plugin/opt.linux_i386/stub_mm.so
+            wdmisc_plugin/opt.linux_i386/wdmisc_mm.so
 
   build-windows:
     runs-on: ubuntu-24.04
@@ -56,6 +66,10 @@ jobs:
         run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+      - name: Build stub_plugin (optimized)
+        run: make -j4 -C stub_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+      - name: Build wdmisc_plugin (optimized)
+        run: make -j4 -C wdmisc_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -63,3 +77,5 @@ jobs:
           path: |
             metamod/opt.win32/metamod.dll
             trace_plugin/opt.win32/trace_mm.dll
+            stub_plugin/opt.win32/stub_mm.dll
+            wdmisc_plugin/opt.win32/wdmisc_mm.dll

--- a/stub_plugin/dllapi.cpp
+++ b/stub_plugin/dllapi.cpp
@@ -101,7 +101,7 @@ static DLL_FUNCTIONS gFunctionTable =
 	NULL,					// pfnAllowLagCompensation
 };
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable,
 		int *interfaceVersion)
 {
 	if(!pFunctionTable) {

--- a/stub_plugin/engine_api.cpp
+++ b/stub_plugin/engine_api.cpp
@@ -248,7 +248,7 @@ enginefuncs_t meta_engfuncs =
 	NULL,						// pfnEngCheckParm()
 };
 
-C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine,
 		int *interfaceVersion) 
 {
 	if(!pengfuncsFromEngine) {

--- a/stub_plugin/h_export.cpp
+++ b/stub_plugin/h_export.cpp
@@ -38,7 +38,7 @@ globalvars_t  *gpGlobals;
 // Receive engine function table from engine.
 // This appears to be the _first_ DLL routine called by the engine, so we
 // do some setup operations here.
-void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
+C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
 {
 	memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
 	gpGlobals = pGlobals;

--- a/stub_plugin/meta_api.cpp
+++ b/stub_plugin/meta_api.cpp
@@ -78,7 +78,7 @@ mutil_funcs_t *gpMetaUtilFuncs;		// metamod utility functions
 //  ifvers			(given) interface_version metamod is using
 //  pPlugInfo		(requested) struct with info about plugin
 //  pMetaUtilFuncs	(given) table of utility functions provided by metamod
-C_DLLEXPORT int Meta_Query(char * /*ifvers */, plugin_info_t **pPlugInfo,
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Query(char * /*ifvers */, plugin_info_t **pPlugInfo,
 		mutil_funcs_t *pMetaUtilFuncs) 
 {
 	// Give metamod our plugin_info struct
@@ -93,8 +93,8 @@ C_DLLEXPORT int Meta_Query(char * /*ifvers */, plugin_info_t **pPlugInfo,
 //  pFunctionTable	(requested) table of function tables this plugin catches
 //  pMGlobals		(given) global vars from metamod
 //  pGamedllFuncs	(given) copy of function tables from game dll
-C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME /* now */, 
-		META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Attach(PLUG_LOADTIME /* now */,
+		META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals,
 		gamedll_funcs_t *pGamedllFuncs) 
 {
 	if(!pMGlobals) {
@@ -114,7 +114,7 @@ C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME /* now */,
 // Metamod detaching plugin from the server.
 // now		(given) current phase, ie during map, etc
 // reason	(given) why detaching (refresh, console unload, forced unload, etc)
-C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME /* now */, 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Detach(PLUG_LOADTIME /* now */,
 		PL_UNLOAD_REASON /* reason */) 
 {
 	return(TRUE);

--- a/trace_plugin/dllapi.cpp
+++ b/trace_plugin/dllapi.cpp
@@ -45,250 +45,250 @@
 #include "log_plugin.h"
 
 // from SDK dlls/game.cpp:
-void GameDLLInit( void ) {
+FORCE_STACK_ALIGN void GameDLLInit( void ) {
 	DLL_TRACE(pfnGameInit, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK dlls/cbase.cpp:
-int DispatchSpawn( edict_t *pent ) {
+FORCE_STACK_ALIGN int DispatchSpawn( edict_t *pent ) {
 	edict_t *ed=pent;
 	DLL_TRACE(pfnSpawn, P_PRE, ("classname=%s",
 				ed ? STRING(ed->v.classname) : "nil"));
 	// 0==Success, -1==Failure ?
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DispatchThink( edict_t *pent ) {
+FORCE_STACK_ALIGN void DispatchThink( edict_t *pent ) {
 	DLL_TRACE(pfnThink, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchUse( edict_t *pentUsed, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchUse( edict_t *pentUsed, edict_t *pentOther ) {
 	DLL_TRACE(pfnUse, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchTouch( edict_t *pentTouched, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchTouch( edict_t *pentTouched, edict_t *pentOther ) {
 	DLL_TRACE(pfnTouch, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchBlocked( edict_t *pentBlocked, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchBlocked( edict_t *pentBlocked, edict_t *pentOther ) {
 	DLL_TRACE(pfnBlocked, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchKeyValue( edict_t *pentKeyvalue, KeyValueData *pkvd ) {
+FORCE_STACK_ALIGN void DispatchKeyValue( edict_t *pentKeyvalue, KeyValueData *pkvd ) {
 	DLL_TRACE(pfnKeyValue, P_PRE, ("classname=%s keyname=%s value=%s", P_PRE,
 			pkvd->szClassName, pkvd->szKeyName, pkvd->szValue));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchSave( edict_t *pent, SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void DispatchSave( edict_t *pent, SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnSave, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int DispatchRestore( edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity ) {
+FORCE_STACK_ALIGN int DispatchRestore( edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity ) {
 	DLL_TRACE(pfnRestore, P_PRE, (""));
 	// 0==Success, -1==Failure ?
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DispatchObjectCollsionBox( edict_t *pent ) {
+FORCE_STACK_ALIGN void DispatchObjectCollsionBox( edict_t *pent ) {
 	edict_t *ed=pent;
 	DLL_TRACE(pfnSetAbsBox, P_PRE, ("classname=%s netname=%s",
 				ed ? STRING(ed->v.classname) : "nil",
 				ed ? STRING(ed->v.netname) : "nil"));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveWriteFields( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
+FORCE_STACK_ALIGN void SaveWriteFields( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
 	DLL_TRACE(pfnSaveWriteFields, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveReadFields( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
+FORCE_STACK_ALIGN void SaveReadFields( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
 	DLL_TRACE(pfnSaveReadFields, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK dlls/world.cpp:
-void SaveGlobalState( SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void SaveGlobalState( SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnSaveGlobalState, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void RestoreGlobalState( SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void RestoreGlobalState( SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnRestoreGlobalState, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ResetGlobalState( void ) {
+FORCE_STACK_ALIGN void ResetGlobalState( void ) {
 	DLL_TRACE(pfnResetGlobalState, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! from SDK dlls/client.cpp:
-BOOL ClientConnect( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]  ) {
+FORCE_STACK_ALIGN BOOL ClientConnect( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]  ) {
 	DLL_TRACE(pfnClientConnect, P_PRE, ("name=%s, addr=%s", pszName, pszAddress));
 	RETURN_META_VALUE(MRES_IGNORED, FALSE);
 }
-void ClientDisconnect( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientDisconnect( edict_t *pEntity ) {
 	// DLL_TRACE(pfnClientDisconnect, P_PRE, ("name=%s", ENTITY_KEYVALUE(pEntity, "name")));
 	DLL_TRACE(pfnClientDisconnect, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientKill( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientKill( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientKill, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientPutInServer( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientPutInServer( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientPutInServer, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientCommand( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientCommand( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientCommand, P_PRE, ("name=%s, cmd='%s %s'", STRING(pEntity->v.netname), CMD_ARGV(0), 
 				CMD_ARGC() >= 1 ? CMD_ARGS() : ""));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientUserInfoChanged( edict_t *pEntity, char *infobuffer ) {
+FORCE_STACK_ALIGN void ClientUserInfoChanged( edict_t *pEntity, char *infobuffer ) {
 	DLL_TRACE(pfnClientUserInfoChanged, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerActivate( edict_t *pEdictList, int edictCount, int clientMax ) {
+FORCE_STACK_ALIGN void ServerActivate( edict_t *pEdictList, int edictCount, int clientMax ) {
 	DLL_TRACE(pfnServerActivate, P_PRE, ("count=%d, max=%d", edictCount, clientMax));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerDeactivate( void ) {
+FORCE_STACK_ALIGN void ServerDeactivate( void ) {
 	DLL_TRACE(pfnServerDeactivate, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void PlayerPreThink( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void PlayerPreThink( edict_t *pEntity ) {
 	DLL_TRACE(pfnPlayerPreThink, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void PlayerPostThink( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void PlayerPostThink( edict_t *pEntity ) {
 	DLL_TRACE(pfnPlayerPostThink, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void StartFrame( void ) {
+FORCE_STACK_ALIGN void StartFrame( void ) {
 	DLL_TRACE(pfnStartFrame, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ParmsNewLevel( void ) {
+FORCE_STACK_ALIGN void ParmsNewLevel( void ) {
 	DLL_TRACE(pfnParmsNewLevel, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ParmsChangeLevel( void ) {
+FORCE_STACK_ALIGN void ParmsChangeLevel( void ) {
 	DLL_TRACE(pfnParmsChangeLevel, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetGameDescription( void ) {
+FORCE_STACK_ALIGN const char *GetGameDescription( void ) {
 	DLL_TRACE(pfnGetGameDescription, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, "");
 }
-void PlayerCustomization( edict_t *pEntity, customization_t *pCust ) {
+FORCE_STACK_ALIGN void PlayerCustomization( edict_t *pEntity, customization_t *pCust ) {
 	DLL_TRACE(pfnPlayerCustomization, P_PRE, ("name=%s", STRING(pEntity->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorConnect( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorConnect( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorConnect, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorDisconnect( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorDisconnect( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorDisconnect, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorThink( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorThink( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorThink, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void Sys_Error( const char *error_string ) {
+FORCE_STACK_ALIGN void Sys_Error( const char *error_string ) {
 	DLL_TRACE(pfnSys_Error, P_PRE, ("string=%s", error_string));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK pm_shared/pm_shared.c:
-void PM_Move ( struct playermove_s *ppmove, int server ) {
+FORCE_STACK_ALIGN void PM_Move ( struct playermove_s *ppmove, int server ) {
 	DLL_TRACE(pfnPM_Move, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void PM_Init( struct playermove_s *ppmove ) {
+FORCE_STACK_ALIGN void PM_Init( struct playermove_s *ppmove ) {
 	DLL_TRACE(pfnPM_Init, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-char PM_FindTextureType( char *name ) {
+FORCE_STACK_ALIGN char PM_FindTextureType( char *name ) {
 	DLL_TRACE(pfnPM_FindTextureType, P_PRE, ("name=%s", name));
 	RETURN_META_VALUE(MRES_IGNORED, '\0');
 }
 
 // from SDK dlls/client.cpp:
-void SetupVisibility( edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas ) {
+FORCE_STACK_ALIGN void SetupVisibility( edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas ) {
 	DLL_TRACE(pfnSetupVisibility, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void UpdateClientData ( const struct edict_s *ent, int sendweapons, struct clientdata_s *cd ) {
+FORCE_STACK_ALIGN void UpdateClientData ( const struct edict_s *ent, int sendweapons, struct clientdata_s *cd ) {
 	DLL_TRACE(pfnUpdateClientData, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int AddToFullPack( struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet ) {
+FORCE_STACK_ALIGN int AddToFullPack( struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet ) {
 	DLL_TRACE(pfnAddToFullPack, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void CreateBaseline( int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs ) {
+FORCE_STACK_ALIGN void CreateBaseline( int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs ) {
 	DLL_TRACE(pfnCreateBaseline, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void RegisterEncoders( void ) {
+FORCE_STACK_ALIGN void RegisterEncoders( void ) {
 	DLL_TRACE(pfnRegisterEncoders, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int GetWeaponData( struct edict_s *player, struct weapon_data_s *info ) {
+FORCE_STACK_ALIGN int GetWeaponData( struct edict_s *player, struct weapon_data_s *info ) {
 	DLL_TRACE(pfnGetWeaponData, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
-void CmdStart( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed ) {
+FORCE_STACK_ALIGN void CmdStart( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed ) {
 	DLL_TRACE(pfnCmdStart, P_PRE, ("name=%s, rand=%d", STRING(player->v.netname), random_seed));
 	RETURN_META(MRES_IGNORED);
 }
-void CmdEnd ( const edict_t *player ) {
+FORCE_STACK_ALIGN void CmdEnd ( const edict_t *player ) {
 	DLL_TRACE(pfnCmdEnd, P_PRE, ("name=%s", STRING(player->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
-int ConnectionlessPacket( const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size ) {
+FORCE_STACK_ALIGN int ConnectionlessPacket( const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size ) {
 	DLL_TRACE(pfnConnectionlessPacket, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int GetHullBounds( int hullnumber, float *mins, float *maxs ) {
+FORCE_STACK_ALIGN int GetHullBounds( int hullnumber, float *mins, float *maxs ) {
 	DLL_TRACE(pfnGetHullBounds, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void CreateInstancedBaselines ( void ) {
+FORCE_STACK_ALIGN void CreateInstancedBaselines ( void ) {
 	DLL_TRACE(pfnCreateInstancedBaselines, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int InconsistentFile( const edict_t *player, const char *filename, char *disconnect_message ) {
+FORCE_STACK_ALIGN int InconsistentFile( const edict_t *player, const char *filename, char *disconnect_message ) {
 	DLL_TRACE(pfnInconsistentFile, P_PRE, ("name=%s, file=%s", STRING(player->v.netname), filename));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int AllowLagCompensation( void ) {
+FORCE_STACK_ALIGN int AllowLagCompensation( void ) {
 	DLL_TRACE(pfnAllowLagCompensation, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
 
 
 // from SDK ?
-void OnFreeEntPrivateData(edict_t *pEnt) {
+FORCE_STACK_ALIGN void OnFreeEntPrivateData(edict_t *pEnt) {
 	NEWDLL_TRACE(pfnOnFreeEntPrivateData, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GameShutdown(void) {
+FORCE_STACK_ALIGN void GameShutdown(void) {
 	NEWDLL_TRACE(pfnGameShutdown, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
+FORCE_STACK_ALIGN int ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
 	NEWDLL_TRACE(pfnShouldCollide, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
 
 // Added 2005-08-11 (no SDK update)
-void CvarValue(const edict_t *pEdict, const char *szValue) {
+FORCE_STACK_ALIGN void CvarValue(const edict_t *pEdict, const char *szValue) {
 	NEWDLL_TRACE(pfnCvarValue, P_PRE, ("player=%s, value=%s", STRING(pEdict->v.netname), szValue?szValue:"nil"));
 	RETURN_META(MRES_IGNORED);
 }
 
 // Added 2005-11-22 (no SDK update)
-void CvarValue2(const edict_t *pEdict, int requestID, const char *cvarName, const char *value) {
+FORCE_STACK_ALIGN void CvarValue2(const edict_t *pEdict, int requestID, const char *cvarName, const char *value) {
 	NEWDLL_TRACE(pfnCvarValue2, P_PRE, ("player=%s, requestID=%d, cvar=%s, value=%s", 
 										STRING(pEdict->v.netname), requestID, cvarName?cvarName:"nil", value?value:"nil"));
 	RETURN_META(MRES_IGNORED);
@@ -377,7 +377,7 @@ static DLL_FUNCTIONS gFunctionTable =
 // It's unclear whether a DLL coded under SDK2 needs to provide the older
 // GetAPI or not..
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable,
 		int *interfaceVersion )
 {
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI2; version=%d", *interfaceVersion);
@@ -421,7 +421,7 @@ static NEW_DLL_FUNCTIONS gNewFunctionTable =
 	CvarValue2,					//! pfnCvarValue2()
 };
 
-C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable,
 		int *interfaceVersion) 
 {
 	LOG_DEVELOPER(PLID, "called: GetNewDLLFunctions; version=%d", 

--- a/trace_plugin/dllapi_post.cpp
+++ b/trace_plugin/dllapi_post.cpp
@@ -43,13 +43,13 @@
 #include "log_plugin.h"
 
 // from SDK dlls/game.cpp:
-void GameDLLInit_Post( void ) {
+FORCE_STACK_ALIGN void GameDLLInit_Post( void ) {
 	DLL_TRACE(pfnGameInit, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK dlls/cbase.cpp:
-int DispatchSpawn_Post( edict_t *pent ) {
+FORCE_STACK_ALIGN int DispatchSpawn_Post( edict_t *pent ) {
 	edict_t *ed=pent;
 	DLL_TRACE(pfnSpawn, P_POST, ("classname=%s, returning %d", 
 				ed ? STRING(ed->v.classname) : "nil",
@@ -57,235 +57,235 @@ int DispatchSpawn_Post( edict_t *pent ) {
 	// 0==Success, -1==Failure ?
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DispatchThink_Post( edict_t *pent ) {
+FORCE_STACK_ALIGN void DispatchThink_Post( edict_t *pent ) {
 	DLL_TRACE(pfnThink, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchUse_Post( edict_t *pentUsed, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchUse_Post( edict_t *pentUsed, edict_t *pentOther ) {
 	DLL_TRACE(pfnUse, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchTouch_Post( edict_t *pentTouched, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchTouch_Post( edict_t *pentTouched, edict_t *pentOther ) {
 	DLL_TRACE(pfnTouch, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchBlocked_Post( edict_t *pentBlocked, edict_t *pentOther ) {
+FORCE_STACK_ALIGN void DispatchBlocked_Post( edict_t *pentBlocked, edict_t *pentOther ) {
 	DLL_TRACE(pfnBlocked, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchKeyValue_Post( edict_t *pentKeyvalue, KeyValueData *pkvd ) {
+FORCE_STACK_ALIGN void DispatchKeyValue_Post( edict_t *pentKeyvalue, KeyValueData *pkvd ) {
 	DLL_TRACE(pfnKeyValue, P_POST, ("classname=%s keyname=%s value=%s",
 			pkvd->szClassName, pkvd->szKeyName, pkvd->szValue));
 	RETURN_META(MRES_IGNORED);
 }
-void DispatchSave_Post( edict_t *pent, SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void DispatchSave_Post( edict_t *pent, SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnSave, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int DispatchRestore_Post( edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity ) {
+FORCE_STACK_ALIGN int DispatchRestore_Post( edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity ) {
 	DLL_TRACE(pfnRestore, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	// 0==Success, -1==Failure ?
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DispatchObjectCollsionBox_Post( edict_t *pent ) {
+FORCE_STACK_ALIGN void DispatchObjectCollsionBox_Post( edict_t *pent ) {
 	DLL_TRACE(pfnSetAbsBox, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveWriteFields_Post( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
+FORCE_STACK_ALIGN void SaveWriteFields_Post( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
 	DLL_TRACE(pfnSaveWriteFields, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveReadFields_Post( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
+FORCE_STACK_ALIGN void SaveReadFields_Post( SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount ) {
 	DLL_TRACE(pfnSaveReadFields, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK dlls/world.cpp:
-void SaveGlobalState_Post( SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void SaveGlobalState_Post( SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnSaveGlobalState, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void RestoreGlobalState_Post( SAVERESTOREDATA *pSaveData ) {
+FORCE_STACK_ALIGN void RestoreGlobalState_Post( SAVERESTOREDATA *pSaveData ) {
 	DLL_TRACE(pfnRestoreGlobalState, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ResetGlobalState_Post( void ) {
+FORCE_STACK_ALIGN void ResetGlobalState_Post( void ) {
 	DLL_TRACE(pfnResetGlobalState, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! from SDK dlls/client.cpp:
-BOOL ClientConnect_Post( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]  ) {
+FORCE_STACK_ALIGN BOOL ClientConnect_Post( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]  ) {
 	BOOL ret=META_RESULT_ORIG_RET(BOOL);
 	if(ret) DLL_TRACE(pfnClientConnect, P_POST, ("returning %d", ret));
 	else DLL_TRACE(pfnClientConnect, P_POST, ("returning %d, reason=%s", ret, szRejectReason));
 	RETURN_META_VALUE(MRES_IGNORED, TRUE);
 }
-void ClientDisconnect_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientDisconnect_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientDisconnect, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientKill_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientKill_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientKill, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientPutInServer_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientPutInServer_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientPutInServer, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientCommand_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void ClientCommand_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnClientCommand, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ClientUserInfoChanged_Post( edict_t *pEntity, char *infobuffer ) {
+FORCE_STACK_ALIGN void ClientUserInfoChanged_Post( edict_t *pEntity, char *infobuffer ) {
 	DLL_TRACE(pfnClientUserInfoChanged, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerActivate_Post( edict_t *pEdictList, int edictCount, int clientMax ) {
+FORCE_STACK_ALIGN void ServerActivate_Post( edict_t *pEdictList, int edictCount, int clientMax ) {
 	DLL_TRACE(pfnServerActivate, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerDeactivate_Post( void ) {
+FORCE_STACK_ALIGN void ServerDeactivate_Post( void ) {
 	DLL_TRACE(pfnServerDeactivate, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void PlayerPreThink_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void PlayerPreThink_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnPlayerPreThink, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void PlayerPostThink_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void PlayerPostThink_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnPlayerPostThink, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void StartFrame_Post( void ) {
+FORCE_STACK_ALIGN void StartFrame_Post( void ) {
 	DLL_TRACE(pfnStartFrame, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ParmsNewLevel_Post( void ) {
+FORCE_STACK_ALIGN void ParmsNewLevel_Post( void ) {
 	DLL_TRACE(pfnParmsNewLevel, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ParmsChangeLevel_Post( void ) {
+FORCE_STACK_ALIGN void ParmsChangeLevel_Post( void ) {
 	DLL_TRACE(pfnParmsChangeLevel, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetGameDescription_Post( void ) {
+FORCE_STACK_ALIGN const char *GetGameDescription_Post( void ) {
 	DLL_TRACE(pfnGetGameDescription, P_POST, ("returning %s", META_RESULT_ORIG_RET(char *)));
 	RETURN_META_VALUE(MRES_IGNORED, "");
 }
-void PlayerCustomization_Post( edict_t *pEntity, customization_t *pCust ) {
+FORCE_STACK_ALIGN void PlayerCustomization_Post( edict_t *pEntity, customization_t *pCust ) {
 	DLL_TRACE(pfnPlayerCustomization, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorConnect_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorConnect_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorConnect, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorDisconnect_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorDisconnect_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorDisconnect, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SpectatorThink_Post( edict_t *pEntity ) {
+FORCE_STACK_ALIGN void SpectatorThink_Post( edict_t *pEntity ) {
 	DLL_TRACE(pfnSpectatorThink, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void Sys_Error_Post( const char *error_string ) {
+FORCE_STACK_ALIGN void Sys_Error_Post( const char *error_string ) {
 	DLL_TRACE(pfnSys_Error, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // from SDK pm_shared/pm_shared.c:
-void PM_Move_Post( struct playermove_s *ppmove, int server ) {
+FORCE_STACK_ALIGN void PM_Move_Post( struct playermove_s *ppmove, int server ) {
 	DLL_TRACE(pfnPM_Move, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void PM_Init_Post( struct playermove_s *ppmove ) {
+FORCE_STACK_ALIGN void PM_Init_Post( struct playermove_s *ppmove ) {
 	DLL_TRACE(pfnPM_Init, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-char PM_FindTextureType_Post( char *name ) {
+FORCE_STACK_ALIGN char PM_FindTextureType_Post( char *name ) {
 	DLL_TRACE(pfnPM_FindTextureType, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, '\0');
 }
 
 // from SDK dlls/client.cpp:
-void SetupVisibility_Post( edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas ) {
+FORCE_STACK_ALIGN void SetupVisibility_Post( edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas ) {
 	DLL_TRACE(pfnSetupVisibility, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void UpdateClientData_Post ( const struct edict_s *ent, int sendweapons, struct clientdata_s *cd ) {
+FORCE_STACK_ALIGN void UpdateClientData_Post ( const struct edict_s *ent, int sendweapons, struct clientdata_s *cd ) {
 	DLL_TRACE(pfnUpdateClientData, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int AddToFullPack_Post( struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet ) {
+FORCE_STACK_ALIGN int AddToFullPack_Post( struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet ) {
 	DLL_TRACE(pfnAddToFullPack, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void CreateBaseline_Post( int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs ) {
+FORCE_STACK_ALIGN void CreateBaseline_Post( int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs ) {
 	DLL_TRACE(pfnCreateBaseline, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void RegisterEncoders_Post( void ) {
+FORCE_STACK_ALIGN void RegisterEncoders_Post( void ) {
 	DLL_TRACE(pfnRegisterEncoders, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int GetWeaponData_Post( struct edict_s *player, struct weapon_data_s *info ) {
+FORCE_STACK_ALIGN int GetWeaponData_Post( struct edict_s *player, struct weapon_data_s *info ) {
 	DLL_TRACE(pfnGetWeaponData, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
-void CmdStart_Post( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed ) {
+FORCE_STACK_ALIGN void CmdStart_Post( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed ) {
 	DLL_TRACE(pfnCmdStart, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CmdEnd_Post ( const edict_t *player ) {
+FORCE_STACK_ALIGN void CmdEnd_Post ( const edict_t *player ) {
 	DLL_TRACE(pfnCmdEnd, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int ConnectionlessPacket_Post( const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size ) {
+FORCE_STACK_ALIGN int ConnectionlessPacket_Post( const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size ) {
 	DLL_TRACE(pfnConnectionlessPacket, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int GetHullBounds_Post( int hullnumber, float *mins, float *maxs ) {
+FORCE_STACK_ALIGN int GetHullBounds_Post( int hullnumber, float *mins, float *maxs ) {
 	DLL_TRACE(pfnGetHullBounds, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void CreateInstancedBaselines_Post ( void ) {
+FORCE_STACK_ALIGN void CreateInstancedBaselines_Post ( void ) {
 	DLL_TRACE(pfnCreateInstancedBaselines, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int InconsistentFile_Post( const edict_t *player, const char *filename, char *disconnect_message ) {
+FORCE_STACK_ALIGN int InconsistentFile_Post( const edict_t *player, const char *filename, char *disconnect_message ) {
 	DLL_TRACE(pfnInconsistentFile, P_POST, ("returning %d, message=%s", META_RESULT_ORIG_RET(int), disconnect_message));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int AllowLagCompensation_Post( void ) {
+FORCE_STACK_ALIGN int AllowLagCompensation_Post( void ) {
 	DLL_TRACE(pfnAllowLagCompensation, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
 
 
 // from SDK ?
-void OnFreeEntPrivateData_Post(edict_t *pEnt) {
+FORCE_STACK_ALIGN void OnFreeEntPrivateData_Post(edict_t *pEnt) {
 	NEWDLL_TRACE(pfnOnFreeEntPrivateData, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GameShutdown_Post(void) {
+FORCE_STACK_ALIGN void GameShutdown_Post(void) {
 	NEWDLL_TRACE(pfnGameShutdown, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int ShouldCollide_Post(edict_t *pentTouched, edict_t *pentOther) {
+FORCE_STACK_ALIGN int ShouldCollide_Post(edict_t *pentTouched, edict_t *pentOther) {
 	NEWDLL_TRACE(pfnShouldCollide, P_POST, ("returning %d", META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 1);
 }
 
 // Added 2005-08-11 (no SDK update)
-void CvarValue_Post(const edict_t *pEdict, const char *szValue)
+FORCE_STACK_ALIGN void CvarValue_Post(const edict_t *pEdict, const char *szValue)
 {
 	NEWDLL_TRACE(pfnCvarValue, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 // Added 2005-11-22 (no SDK update)
-void CvarValue2_Post(const edict_t *pEdict, int requestID, const char *cvarName, const char *value) {
+FORCE_STACK_ALIGN void CvarValue2_Post(const edict_t *pEdict, int requestID, const char *cvarName, const char *value) {
 	NEWDLL_TRACE(pfnCvarValue2, P_POST, ("player=%s, requestID=%d, cvar=%s, value=%s", 
 										STRING(pEdict->v.netname), requestID, cvarName?cvarName:"nil", value?value:"nil"));
 	RETURN_META(MRES_IGNORED);
@@ -357,7 +357,7 @@ static DLL_FUNCTIONS gFunctionTable_Post =
 	AllowLagCompensation_Post,		//! pfnAllowLagCompensation()	(wd) SDK2
 };
 
-C_DLLEXPORT int GetEntityAPI_Post( DLL_FUNCTIONS *pFunctionTable, int interfaceVersion )
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI_Post( DLL_FUNCTIONS *pFunctionTable, int interfaceVersion )
 {
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI_Post; version=%d", interfaceVersion);
 	if(!pFunctionTable) {
@@ -372,7 +372,7 @@ C_DLLEXPORT int GetEntityAPI_Post( DLL_FUNCTIONS *pFunctionTable, int interfaceV
 	return(TRUE);
 }
 
-C_DLLEXPORT int GetEntityAPI2_Post( DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion )
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2_Post( DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion )
 {
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI2_Post; version=%d", *interfaceVersion);
 	if(!pFunctionTable) {
@@ -399,7 +399,7 @@ static NEW_DLL_FUNCTIONS gNewFunctionTable_Post =
 	CvarValue2_Post,				//! pfnCvarValue2()
 };
 
-C_DLLEXPORT int GetNewDLLFunctions_Post( NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion ) 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetNewDLLFunctions_Post( NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion ) 
 {
 	LOG_DEVELOPER(PLID, "called: GetNewDLLFunctions_Post; version=%d", *interfaceVersion);
 	if(!pNewFunctionTable) {

--- a/trace_plugin/engine_api.cpp
+++ b/trace_plugin/engine_api.cpp
@@ -45,15 +45,15 @@
 #include "support_meta.h"		// MAX_STRBUF_LEN
 #include "log_plugin.h"
 
-int PrecacheModel(char *s) {
+FORCE_STACK_ALIGN int PrecacheModel(char *s) {
 	ENGINE_TRACE(pfnPrecacheModel, P_PRE, ("model=%s", s));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int PrecacheSound(char *s) {
+FORCE_STACK_ALIGN int PrecacheSound(char *s) {
 	ENGINE_TRACE(pfnPrecacheSound, P_PRE, ("sound=%s", s));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void SetModel(edict_t *e, const char *m) {
+FORCE_STACK_ALIGN void SetModel(edict_t *e, const char *m) {
 	edict_t *ed = e;
 	ENGINE_TRACE(pfnSetModel, P_PRE, ("classname=%s netname=%s model=%s", 
 				ed ? STRING(ed->v.classname) : "nil",
@@ -61,116 +61,116 @@ void SetModel(edict_t *e, const char *m) {
 				m));
 	RETURN_META(MRES_IGNORED);
 }
-int ModelIndex(const char *m) {
+FORCE_STACK_ALIGN int ModelIndex(const char *m) {
 	ENGINE_TRACE(pfnModelIndex, P_PRE, ("model=%s", m));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int ModelFrames(int modelIndex) {
+FORCE_STACK_ALIGN int ModelFrames(int modelIndex) {
 	ENGINE_TRACE(pfnModelFrames, P_PRE, ("index=%d", modelIndex));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
+FORCE_STACK_ALIGN void SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
 	ENGINE_TRACE(pfnSetSize, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangeLevel(char *s1, char *s2) {
+FORCE_STACK_ALIGN void ChangeLevel(char *s1, char *s2) {
 	ENGINE_TRACE(pfnChangeLevel, P_PRE, ("s1=%s, s2=%s", s1, s2));
 	RETURN_META(MRES_IGNORED);
 }
-void GetSpawnParms(edict_t *ent) {
+FORCE_STACK_ALIGN void GetSpawnParms(edict_t *ent) {
 	ENGINE_TRACE(pfnGetSpawnParms, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveSpawnParms(edict_t *ent) {
+FORCE_STACK_ALIGN void SaveSpawnParms(edict_t *ent) {
 	ENGINE_TRACE(pfnSaveSpawnParms, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-float VecToYaw(const float *rgflVector) {
+FORCE_STACK_ALIGN float VecToYaw(const float *rgflVector) {
 	ENGINE_TRACE(pfnVecToYaw, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-void VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
+FORCE_STACK_ALIGN void VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
 	ENGINE_TRACE(pfnVecToAngles, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
+FORCE_STACK_ALIGN void MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
 	ENGINE_TRACE(pfnMoveToOrigin, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangeYaw(edict_t *ent) {
+FORCE_STACK_ALIGN void ChangeYaw(edict_t *ent) {
 	ENGINE_TRACE(pfnChangeYaw, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangePitch(edict_t *ent) {
+FORCE_STACK_ALIGN void ChangePitch(edict_t *ent) {
 	ENGINE_TRACE(pfnChangePitch, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-edict_t *FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
+FORCE_STACK_ALIGN edict_t *FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
 	edict_t *ed=pEdictStartSearchAfter;
 	ENGINE_TRACE(pfnFindEntityByString, P_PRE, ("start=%s field=%s value=%s", 
 				ed ? STRING(ed->v.classname) : "nil", pszField, pszValue));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int GetEntityIllum(edict_t *pEnt) {
+FORCE_STACK_ALIGN int GetEntityIllum(edict_t *pEnt) {
 	ENGINE_TRACE(pfnGetEntityIllum, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-edict_t *FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
+FORCE_STACK_ALIGN edict_t *FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
 	ENGINE_TRACE(pfnFindEntityInSphere, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *FindClientInPVS(edict_t *pEdict) {
+FORCE_STACK_ALIGN edict_t *FindClientInPVS(edict_t *pEdict) {
 	ENGINE_TRACE(pfnFindClientInPVS, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *EntitiesInPVS(edict_t *pplayer) {
+FORCE_STACK_ALIGN edict_t *EntitiesInPVS(edict_t *pplayer) {
 	ENGINE_TRACE(pfnEntitiesInPVS, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-void MakeVectors(const float *rgflVector) {
+FORCE_STACK_ALIGN void MakeVectors(const float *rgflVector) {
 	ENGINE_TRACE(pfnMakeVectors, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
+FORCE_STACK_ALIGN void AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
 	ENGINE_TRACE(pfnAngleVectors, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-edict_t *CreateEntity(void) {
+FORCE_STACK_ALIGN edict_t *CreateEntity(void) {
 	ENGINE_TRACE(pfnCreateEntity, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void RemoveEntity(edict_t *e) {
+FORCE_STACK_ALIGN void RemoveEntity(edict_t *e) {
 	ENGINE_TRACE(pfnRemoveEntity, P_PRE, ("name=%s", STRING(e->v.classname)));
 	RETURN_META(MRES_IGNORED);
 }
-edict_t *CreateNamedEntity(int className) {
+FORCE_STACK_ALIGN edict_t *CreateNamedEntity(int className) {
 	ENGINE_TRACE(pfnCreateNamedEntity, P_PRE, ("name=%s", STRING(className)));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-void MakeStatic(edict_t *ent) {
+FORCE_STACK_ALIGN void MakeStatic(edict_t *ent) {
 	ENGINE_TRACE(pfnMakeStatic, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int EntIsOnFloor(edict_t *e) {
+FORCE_STACK_ALIGN int EntIsOnFloor(edict_t *e) {
 	ENGINE_TRACE(pfnEntIsOnFloor, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int DropToFloor(edict_t *e) {
+FORCE_STACK_ALIGN int DropToFloor(edict_t *e) {
 	ENGINE_TRACE(pfnDropToFloor, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
+FORCE_STACK_ALIGN int WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
 	ENGINE_TRACE(pfnWalkMove, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void SetOrigin(edict_t *e, const float *rgflOrigin) {
+FORCE_STACK_ALIGN void SetOrigin(edict_t *e, const float *rgflOrigin) {
 	edict_t *ed = e;
 	ENGINE_TRACE(pfnSetOrigin, P_PRE, ("classname=%s netname=%s",
 				ed ? STRING(ed->v.classname) : "nil",
@@ -178,57 +178,57 @@ void SetOrigin(edict_t *e, const float *rgflOrigin) {
 	RETURN_META(MRES_IGNORED);
 }
 
-void EmitSound(edict_t *entity, int channel, const char *sample, /*int*/float volume, float attenuation, int fFlags, int pitch) {
+FORCE_STACK_ALIGN void EmitSound(edict_t *entity, int channel, const char *sample, /*int*/float volume, float attenuation, int fFlags, int pitch) {
 	ENGINE_TRACE(pfnEmitSound, P_PRE, ("sample=%s", sample));
 	RETURN_META(MRES_IGNORED);
 }
-void EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
+FORCE_STACK_ALIGN void EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
 	ENGINE_TRACE(pfnEmitAmbientSound, P_PRE, ("sample=%s", samp));
 	RETURN_META(MRES_IGNORED);
 }
 
-void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceLine, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceToss, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN int TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceMonsterHull, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceHull, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceModel, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
+FORCE_STACK_ALIGN const char *TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
 	ENGINE_TRACE(pfnTraceTexture, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceSphere, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
+FORCE_STACK_ALIGN void GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
 	ENGINE_TRACE(pfnGetAimVector, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ServerCommand(char *str) {
+FORCE_STACK_ALIGN void ServerCommand(char *str) {
 	ENGINE_TRACE(pfnServerCommand, P_PRE, ("cmd=%s", str));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerExecute(void) {
+FORCE_STACK_ALIGN void ServerExecute(void) {
 	ENGINE_TRACE(pfnServerExecute, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void engClientCommand(edict_t *pEdict, char *szFmt, ...) {
+FORCE_STACK_ALIGN void engClientCommand(edict_t *pEdict, char *szFmt, ...) {
 	va_list ap;
 	char buf[1024];
 	char *cp;
@@ -241,24 +241,24 @@ void engClientCommand(edict_t *pEdict, char *szFmt, ...) {
 	RETURN_META(MRES_IGNORED);
 }
 
-void ParticleEffect(const float *org, const float *dir, float color, float count) {
+FORCE_STACK_ALIGN void ParticleEffect(const float *org, const float *dir, float color, float count) {
 	ENGINE_TRACE(pfnParticleEffect, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void LightStyle(int style, char *val) {
+FORCE_STACK_ALIGN void LightStyle(int style, char *val) {
 	ENGINE_TRACE(pfnLightStyle, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int DecalIndex(const char *name) {
+FORCE_STACK_ALIGN int DecalIndex(const char *name) {
 	ENGINE_TRACE(pfnDecalIndex, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int PointContents(const float *rgflVector) {
+FORCE_STACK_ALIGN int PointContents(const float *rgflVector) {
 	ENGINE_TRACE(pfnPointContents, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
+FORCE_STACK_ALIGN void MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
 	const char *name, *dest;
 	name=GET_USER_MSG_NAME(PLID, msg_type, NULL);
 	if(!name) name="unknown";
@@ -269,68 +269,68 @@ void MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed)
 				ed ? STRING(ed->v.netname) : "nil"));
 	RETURN_META(MRES_IGNORED);
 }
-void MessageEnd(void) {
+FORCE_STACK_ALIGN void MessageEnd(void) {
 	ENGINE_TRACE(pfnMessageEnd, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void WriteByte(int iValue) {
+FORCE_STACK_ALIGN void WriteByte(int iValue) {
 	ENGINE_TRACE(pfnWriteByte, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteChar(int iValue) {
+FORCE_STACK_ALIGN void WriteChar(int iValue) {
 	ENGINE_TRACE(pfnWriteChar, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteShort(int iValue) {
+FORCE_STACK_ALIGN void WriteShort(int iValue) {
 	ENGINE_TRACE(pfnWriteShort, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteLong(int iValue) {
+FORCE_STACK_ALIGN void WriteLong(int iValue) {
 	ENGINE_TRACE(pfnWriteLong, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteAngle(float flValue) {
+FORCE_STACK_ALIGN void WriteAngle(float flValue) {
 	ENGINE_TRACE(pfnWriteAngle, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteCoord(float flValue) {
+FORCE_STACK_ALIGN void WriteCoord(float flValue) {
 	ENGINE_TRACE(pfnWriteCoord, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteString(const char *sz) {
+FORCE_STACK_ALIGN void WriteString(const char *sz) {
 	ENGINE_TRACE(pfnWriteString, P_PRE, ("string=%s", sz));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteEntity(int iValue) {
+FORCE_STACK_ALIGN void WriteEntity(int iValue) {
 	ENGINE_TRACE(pfnWriteEntity, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void CVarRegister(cvar_t *pCvar) {
+FORCE_STACK_ALIGN void CVarRegister(cvar_t *pCvar) {
 	ENGINE_TRACE(pfnCVarRegister, P_PRE, ("cvar=%s", pCvar->name));
 	RETURN_META(MRES_IGNORED);
 }
-float CVarGetFloat(const char *szVarName) {
+FORCE_STACK_ALIGN float CVarGetFloat(const char *szVarName) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnCVarGetFloat, P_PRE, ("cvar=%s", szVarName));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-const char *CVarGetString(const char *szVarName) {
+FORCE_STACK_ALIGN const char *CVarGetString(const char *szVarName) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnCVarGetString, P_PRE, ("cvar=%s", szVarName));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void CVarSetFloat(const char *szVarName, float flValue) {
+FORCE_STACK_ALIGN void CVarSetFloat(const char *szVarName, float flValue) {
 	ENGINE_TRACE(pfnCVarSetFloat, P_PRE, ("cvar=%s, val=%f", szVarName, flValue));
 	RETURN_META(MRES_IGNORED);
 }
-void CVarSetString(const char *szVarName, const char *szValue) {
+FORCE_STACK_ALIGN void CVarSetString(const char *szVarName, const char *szValue) {
 	ENGINE_TRACE(pfnCVarSetString, P_PRE, ("cvar=%s, val=%s", szVarName, szValue));
 	RETURN_META(MRES_IGNORED);
 }
 
-void AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
+FORCE_STACK_ALIGN void AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	char *astr;
 	va_list ap;
 	char buf[MAX_STRBUF_LEN];
@@ -365,9 +365,9 @@ void AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	RETURN_META(MRES_IGNORED);
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-void EngineFprintf(FILE *pfile, char *szFmt, ...) {
+FORCE_STACK_ALIGN void EngineFprintf(FILE *pfile, char *szFmt, ...) {
 #else
-void EngineFprintf(void *pfile, char *szFmt, ...) {
+FORCE_STACK_ALIGN void EngineFprintf(void *pfile, char *szFmt, ...) {
 #endif
 	va_list ap;
 	char buf[1024];
@@ -379,257 +379,257 @@ void EngineFprintf(void *pfile, char *szFmt, ...) {
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-void *PvAllocEntPrivateData(edict_t *pEdict, long cb) {
+FORCE_STACK_ALIGN void *PvAllocEntPrivateData(edict_t *pEdict, long cb) {
 #else
-void *PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
+FORCE_STACK_ALIGN void *PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
 #endif
 	ENGINE_TRACE(pfnPvAllocEntPrivateData, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void *PvEntPrivateData(edict_t *pEdict) {
+FORCE_STACK_ALIGN void *PvEntPrivateData(edict_t *pEdict) {
 	ENGINE_TRACE(pfnPvEntPrivateData, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void FreeEntPrivateData(edict_t *pEdict) {
+FORCE_STACK_ALIGN void FreeEntPrivateData(edict_t *pEdict) {
 	ENGINE_TRACE(pfnFreeEntPrivateData, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-const char *SzFromIndex(int iString) {
+FORCE_STACK_ALIGN const char *SzFromIndex(int iString) {
 	ENGINE_TRACE(pfnSzFromIndex, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int AllocString(const char *szValue) {
+FORCE_STACK_ALIGN int AllocString(const char *szValue) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnAllocString, P_PRE, ("str=%s", szValue));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-struct entvars_s *GetVarsOfEnt(edict_t *pEdict) {
+FORCE_STACK_ALIGN struct entvars_s *GetVarsOfEnt(edict_t *pEdict) {
 	ENGINE_TRACE(pfnGetVarsOfEnt, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *PEntityOfEntOffset(int iEntOffset) {
+FORCE_STACK_ALIGN edict_t *PEntityOfEntOffset(int iEntOffset) {
 	ENGINE_TRACE(pfnPEntityOfEntOffset, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int EntOffsetOfPEntity(const edict_t *pEdict) {
+FORCE_STACK_ALIGN int EntOffsetOfPEntity(const edict_t *pEdict) {
 	const edict_t *ed=pEdict;
 	ENGINE_TRACE(pfnEntOffsetOfPEntity, P_PRE, ("classname=%s netname=%s",
 				ed ? STRING(ed->v.classname) : "nil",
 				ed ? STRING(ed->v.netname) : "nil"));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int IndexOfEdict(const edict_t *pEdict) {
+FORCE_STACK_ALIGN int IndexOfEdict(const edict_t *pEdict) {
 	ENGINE_TRACE(pfnIndexOfEdict, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-edict_t *PEntityOfEntIndex(int iEntIndex) {
+FORCE_STACK_ALIGN edict_t *PEntityOfEntIndex(int iEntIndex) {
 	ENGINE_TRACE(pfnPEntityOfEntIndex, P_PRE, ("index=%d", iEntIndex));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *FindEntityByVars(struct entvars_s *pvars) {
+FORCE_STACK_ALIGN edict_t *FindEntityByVars(struct entvars_s *pvars) {
 	ENGINE_TRACE(pfnFindEntityByVars, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void *GetModelPtr(edict_t *pEdict) {
+FORCE_STACK_ALIGN void *GetModelPtr(edict_t *pEdict) {
 	ENGINE_TRACE(pfnGetModelPtr, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int RegUserMsg(const char *pszName, int iSize) {
+FORCE_STACK_ALIGN int RegUserMsg(const char *pszName, int iSize) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnRegUserMsg, P_PRE, ("msg=%s size=%d", pszName, iSize));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void AnimationAutomove(const edict_t *pEdict, float flTime) {
+FORCE_STACK_ALIGN void AnimationAutomove(const edict_t *pEdict, float flTime) {
 	ENGINE_TRACE(pfnAnimationAutomove, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
+FORCE_STACK_ALIGN void GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
 	ENGINE_TRACE(pfnGetBonePosition, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-unsigned long FunctionFromName( const char *pName ) {
+FORCE_STACK_ALIGN unsigned long FunctionFromName( const char *pName ) {
 #else
-uint32 FunctionFromName( const char *pName ) {
+FORCE_STACK_ALIGN uint32 FunctionFromName( const char *pName ) {
 #endif
 	ENGINE_TRACE(pfnFunctionFromName, P_PRE, ("name=%s", pName));
 	RETURN_META_VALUE(MRES_IGNORED, 0UL);
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-const char *NameForFunction( unsigned long function ) {
+FORCE_STACK_ALIGN const char *NameForFunction( unsigned long function ) {
 #else
-const char *NameForFunction( uint32 function ) {
+FORCE_STACK_ALIGN const char *NameForFunction( uint32 function ) {
 #endif
 	ENGINE_TRACE(pfnNameForFunction, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
 //! JOHN: engine callbacks so game DLL can print messages to individual clients
-void ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
+FORCE_STACK_ALIGN void ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
 	ENGINE_TRACE(pfnClientPrintf, P_PRE, ("msg=%s", szMsg));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerPrint( const char *szMsg ) {
+FORCE_STACK_ALIGN void ServerPrint( const char *szMsg ) {
 	ENGINE_TRACE(pfnServerPrint, P_PRE, ("msg=%s", szMsg));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! these 3 added so game DLL can easily access client 'cmd' strings
-const char *Cmd_Args( void ) {
+FORCE_STACK_ALIGN const char *Cmd_Args( void ) {
 	// trace output in Post
 	ENGINE_TRACE(pfnCmd_Args, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-const char *Cmd_Argv( int argc ) {
+FORCE_STACK_ALIGN const char *Cmd_Argv( int argc ) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnCmd_Argv, P_PRE, ("argc=%d", argc));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int Cmd_Argc( void ) {
+FORCE_STACK_ALIGN int Cmd_Argc( void ) {
 	// trace output in Post
 	ENGINE_TRACE(pfnCmd_Argc, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
+FORCE_STACK_ALIGN void GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
 	ENGINE_TRACE(pfnGetAttachment, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void CRC32_Init(CRC32_t *pulCRC) {
+FORCE_STACK_ALIGN void CRC32_Init(CRC32_t *pulCRC) {
 	ENGINE_TRACE(pfnCRC32_Init, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
+FORCE_STACK_ALIGN void CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
 	ENGINE_TRACE(pfnCRC32_ProcessBuffer, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
+FORCE_STACK_ALIGN void CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
 	ENGINE_TRACE(pfnCRC32_ProcessByte, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-CRC32_t CRC32_Final(CRC32_t pulCRC) {
+FORCE_STACK_ALIGN CRC32_t CRC32_Final(CRC32_t pulCRC) {
 	ENGINE_TRACE(pfnCRC32_Final, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-long RandomLong(long lLow, long lHigh) {
+FORCE_STACK_ALIGN long RandomLong(long lLow, long lHigh) {
 #else
-int32 RandomLong(int32 lLow, int32 lHigh) {
+FORCE_STACK_ALIGN int32 RandomLong(int32 lLow, int32 lHigh) {
 #endif
 	// more output in Post
 	ENGINE_TRACE(pfnRandomLong, P_PRE, ("low=%ld, high=%ld", lLow, lHigh));
 	RETURN_META_VALUE(MRES_IGNORED, 0L);
 }
-float RandomFloat(float flLow, float flHigh) {
+FORCE_STACK_ALIGN float RandomFloat(float flLow, float flHigh) {
 	// more output in Post
 	ENGINE_TRACE(pfnRandomFloat, P_PRE, ("low=%f, high=%f", flLow, flHigh));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
 
-void SetView(const edict_t *pClient, const edict_t *pViewent ) {
+FORCE_STACK_ALIGN void SetView(const edict_t *pClient, const edict_t *pViewent ) {
 	ENGINE_TRACE(pfnSetView, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-float Time( void ) {
+FORCE_STACK_ALIGN float Time( void ) {
 	// trace output in Post
 	ENGINE_TRACE(pfnTime, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-void CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
+FORCE_STACK_ALIGN void CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
 	ENGINE_TRACE(pfnCrosshairAngle, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-byte *LoadFileForMe(char *filename, int *pLength) {
+FORCE_STACK_ALIGN byte *LoadFileForMe(char *filename, int *pLength) {
 	ENGINE_TRACE(pfnLoadFileForMe, P_PRE, ("file=%s", filename));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void FreeFile(void *buffer) {
+FORCE_STACK_ALIGN void FreeFile(void *buffer) {
 	ENGINE_TRACE(pfnFreeFile, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! trigger_endsection
-void EndSection(const char *pszSectionName) {
+FORCE_STACK_ALIGN void EndSection(const char *pszSectionName) {
 	ENGINE_TRACE(pfnEndSection, P_PRE, ("section=%s", pszSectionName));
 	RETURN_META(MRES_IGNORED);
 }
-int CompareFileTime(char *filename1, char *filename2, int *iCompare) {
+FORCE_STACK_ALIGN int CompareFileTime(char *filename1, char *filename2, int *iCompare) {
 	ENGINE_TRACE(pfnCompareFileTime, P_PRE, ("file1=%s, file2=%s", filename1, filename2));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void GetGameDir(char *szGetGameDir) {
+FORCE_STACK_ALIGN void GetGameDir(char *szGetGameDir) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetGameDir, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void Cvar_RegisterVariable(cvar_t *variable) {
+FORCE_STACK_ALIGN void Cvar_RegisterVariable(cvar_t *variable) {
 	ENGINE_TRACE(pfnCvar_RegisterVariable, P_PRE, ("cvar=%s", variable->name));
 	RETURN_META(MRES_IGNORED);
 }
-void FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
+FORCE_STACK_ALIGN void FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
 	ENGINE_TRACE(pfnFadeClientVolume, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
+FORCE_STACK_ALIGN void SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
 	ENGINE_TRACE(pfnSetClientMaxspeed, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 //! returns NULL if fake client can't be created
-edict_t * CreateFakeClient(const char *netname) {
+FORCE_STACK_ALIGN edict_t * CreateFakeClient(const char *netname) {
 	ENGINE_TRACE(pfnCreateFakeClient, P_PRE, ("name=%s", netname));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
+FORCE_STACK_ALIGN void RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
 	ENGINE_TRACE(pfnRunPlayerMove, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int NumberOfEntities(void) {
+FORCE_STACK_ALIGN int NumberOfEntities(void) {
 	// trace output in Post
 	ENGINE_TRACE(pfnNumberOfEntities, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
 //! passing in NULL gets the serverinfo
-char *GetInfoKeyBuffer(edict_t *e) {
+FORCE_STACK_ALIGN char *GetInfoKeyBuffer(edict_t *e) {
 	ENGINE_TRACE(pfnGetInfoKeyBuffer, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-char *InfoKeyValue(char *infobuffer, char *key) {
+FORCE_STACK_ALIGN char *InfoKeyValue(char *infobuffer, char *key) {
 	ENGINE_TRACE(pfnInfoKeyValue, P_PRE, ("key=%s", key));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void SetKeyValue(char *infobuffer, char *key, char *value) {
+FORCE_STACK_ALIGN void SetKeyValue(char *infobuffer, char *key, char *value) {
 	ENGINE_TRACE(pfnSetKeyValue, P_PRE, ("key=%s, value=%s", key, value));
 	RETURN_META(MRES_IGNORED);
 }
-void SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
+FORCE_STACK_ALIGN void SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
 	ENGINE_TRACE(pfnSetClientKeyValue, P_PRE, ("index=%d, key=%s, value=%s", clientIndex, key, value));
 	RETURN_META(MRES_IGNORED);
 }
 
-int IsMapValid(char *filename) {
+FORCE_STACK_ALIGN int IsMapValid(char *filename) {
 	// more trace output in Post
 	ENGINE_TRACE(pfnIsMapValid, P_PRE, ("filename=%s", filename));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
+FORCE_STACK_ALIGN void StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
 	ENGINE_TRACE(pfnStaticDecal, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int PrecacheGeneric(char *s) {
+FORCE_STACK_ALIGN int PrecacheGeneric(char *s) {
 	ENGINE_TRACE(pfnPrecacheGeneric, P_PRE, ("name=%s", s));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 //! returns the server assigned userid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-int GetPlayerUserId(edict_t *e ) {
+FORCE_STACK_ALIGN int GetPlayerUserId(edict_t *e ) {
 	// more trace output in Post
 	edict_t *ed = e;
 	ENGINE_TRACE(pfnGetPlayerUserId, P_PRE, ("netname=%s",
@@ -642,16 +642,16 @@ void BuildSoundMsg(edict_t *entity, int channel, const char *sample, /*int*/floa
 	RETURN_META(MRES_IGNORED);
 }
 //! is this a dedicated server?
-int IsDedicatedServer(void) {
+FORCE_STACK_ALIGN int IsDedicatedServer(void) {
 	ENGINE_TRACE(pfnIsDedicatedServer, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-cvar_t *CVarGetPointer(const char *szVarName) {
+FORCE_STACK_ALIGN cvar_t *CVarGetPointer(const char *szVarName) {
 	ENGINE_TRACE(pfnCVarGetPointer, P_PRE, ("cvar=%s", szVarName));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 //! returns the server assigned WONid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-unsigned int GetPlayerWONId(edict_t *e) {
+FORCE_STACK_ALIGN unsigned int GetPlayerWONId(edict_t *e) {
 	// more output in Post
 	edict_t *ed = e;
 	ENGINE_TRACE(pfnGetPlayerWONId, P_PRE, ("netname=%s",
@@ -660,23 +660,23 @@ unsigned int GetPlayerWONId(edict_t *e) {
 }
 
 //! YWB 8/1/99 TFF Physics additions
-void Info_RemoveKey( char *s, const char *key ) {
+FORCE_STACK_ALIGN void Info_RemoveKey( char *s, const char *key ) {
 	ENGINE_TRACE(pfnInfo_RemoveKey, P_PRE, ("key=%s", key));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
+FORCE_STACK_ALIGN const char *GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
 	ENGINE_TRACE(pfnGetPhysicsKeyValue, P_PRE, ("key=%s", key));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
+FORCE_STACK_ALIGN void SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
 	ENGINE_TRACE(pfnSetPhysicsKeyValue, P_PRE, ("key=%s, value=%s", key, value));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetPhysicsInfoString( const edict_t *pClient ) {
+FORCE_STACK_ALIGN const char *GetPhysicsInfoString( const edict_t *pClient ) {
 	ENGINE_TRACE(pfnGetPhysicsInfoString, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-unsigned short PrecacheEvent( int type, const char *psz ) {
+FORCE_STACK_ALIGN unsigned short PrecacheEvent( int type, const char *psz ) {
 	ENGINE_TRACE(pfnPrecacheEvent, P_PRE, ("event=%s", psz));
 	RETURN_META_VALUE(MRES_IGNORED, 0U);
 }
@@ -686,64 +686,64 @@ void PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventinde
 	RETURN_META(MRES_IGNORED);
 }
 
-unsigned char *SetFatPVS( float *org ) {
+FORCE_STACK_ALIGN unsigned char *SetFatPVS( float *org ) {
 	ENGINE_TRACE(pfnSetFatPVS, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-unsigned char *SetFatPAS( float *org ) {
+FORCE_STACK_ALIGN unsigned char *SetFatPAS( float *org ) {
 	ENGINE_TRACE(pfnSetFatPAS, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int CheckVisibility( const edict_t *entity, unsigned char *pset ) {
+FORCE_STACK_ALIGN int CheckVisibility( const edict_t *entity, unsigned char *pset ) {
 	ENGINE_TRACE(pfnCheckVisibility, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN void DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaSetField, P_PRE, ("field=%s", fieldname));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN void DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaUnsetField, P_PRE, ("field=%s", fieldname));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
+FORCE_STACK_ALIGN void DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
 	ENGINE_TRACE(pfnDeltaAddEncoder, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int GetCurrentPlayer( void ) {
+FORCE_STACK_ALIGN int GetCurrentPlayer( void ) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetCurrentPlayer, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int CanSkipPlayer( const edict_t *player ) {
+FORCE_STACK_ALIGN int CanSkipPlayer( const edict_t *player ) {
 	ENGINE_TRACE(pfnCanSkipPlayer, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN int DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaFindField, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+FORCE_STACK_ALIGN void DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	ENGINE_TRACE(pfnDeltaSetFieldByIndex, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+FORCE_STACK_ALIGN void DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	ENGINE_TRACE(pfnDeltaUnsetFieldByIndex, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void SetGroupMask( int mask, int op ) {
+FORCE_STACK_ALIGN void SetGroupMask( int mask, int op ) {
 	ENGINE_TRACE(pfnSetGroupMask, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-int engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
+FORCE_STACK_ALIGN int engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
 	ENGINE_TRACE(pfnCreateInstancedBaseline, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void Cvar_DirectSet( struct cvar_s *var, char *value ) {
+FORCE_STACK_ALIGN void Cvar_DirectSet( struct cvar_s *var, char *value ) {
 	ENGINE_TRACE(pfnCvar_DirectSet, P_PRE, ("cvar=%s", var->name));
 	RETURN_META(MRES_IGNORED);
 }
@@ -751,17 +751,17 @@ void Cvar_DirectSet( struct cvar_s *var, char *value ) {
 //! Forces the client and server to be running with the same version of the specified file
 //!( e.g., a player model ).
 //! Calling this has no effect in single player
-void ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
+FORCE_STACK_ALIGN void ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
 	ENGINE_TRACE(pfnForceUnmodified, P_PRE, ("file=%s", filename));
 	RETURN_META(MRES_IGNORED);
 }
 
-void GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
+FORCE_STACK_ALIGN void GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
 	ENGINE_TRACE(pfnGetPlayerStats, P_PRE, ("name=%s", STRING(pClient->v.netname)));
 	RETURN_META(MRES_IGNORED);
 }
 
-void AddServerCommand( char *cmd_name, void (*function) (void) ) {
+FORCE_STACK_ALIGN void AddServerCommand( char *cmd_name, void (*function) (void) ) {
 	ENGINE_TRACE(pfnAddServerCommand, P_PRE, ("cmd=%s", cmd_name));
 	RETURN_META(MRES_IGNORED);
 }
@@ -770,18 +770,18 @@ void AddServerCommand( char *cmd_name, void (*function) (void) ) {
 
 //! For voice communications, set which clients hear eachother.
 //! NOTE: these functions take player entity indices (starting at 1).
-qboolean Voice_GetClientListening(int iReceiver, int iSender) {
+FORCE_STACK_ALIGN qboolean Voice_GetClientListening(int iReceiver, int iSender) {
 	ENGINE_TRACE(pfnVoice_GetClientListening, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, false);
 }
-qboolean Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
+FORCE_STACK_ALIGN qboolean Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
 	ENGINE_TRACE(pfnVoice_SetClientListening, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, false);
 }
 
 // Added for HL 1109 (no SDK update):
 
-const char *GetPlayerAuthId(edict_t *e) {
+FORCE_STACK_ALIGN const char *GetPlayerAuthId(edict_t *e) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetPlayerAuthId, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
@@ -789,57 +789,57 @@ const char *GetPlayerAuthId(edict_t *e) {
 
 // Added 2003/11/10 (no SDK update):
 
-sequenceEntry_s*SequenceGet(const char* fileName, const char* entryName) {
+FORCE_STACK_ALIGN sequenceEntry_s*SequenceGet(const char* fileName, const char* entryName) {
 	ENGINE_TRACE(pfnSequenceGet, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-sentenceEntry_s *SequencePickSentence(const char* groupName, int pickMethod, int *picked) {
+FORCE_STACK_ALIGN sentenceEntry_s *SequencePickSentence(const char* groupName, int pickMethod, int *picked) {
 	ENGINE_TRACE(pfnSequencePickSentence, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int GetFileSize(char *filename) {
+FORCE_STACK_ALIGN int GetFileSize(char *filename) {
 	ENGINE_TRACE(pfnGetFileSize, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-unsigned int GetApproxWavePlayLen(const char *filepath) {
+FORCE_STACK_ALIGN unsigned int GetApproxWavePlayLen(const char *filepath) {
 	ENGINE_TRACE(pfnGetApproxWavePlayLen, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int IsCareerMatch(void) {
+FORCE_STACK_ALIGN int IsCareerMatch(void) {
 	ENGINE_TRACE(pfnIsCareerMatch, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int GetLocalizedStringLength(const char *label) {
+FORCE_STACK_ALIGN int GetLocalizedStringLength(const char *label) {
 	ENGINE_TRACE(pfnGetLocalizedStringLength, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void RegisterTutorMessageShown(int mid) {
+FORCE_STACK_ALIGN void RegisterTutorMessageShown(int mid) {
 	ENGINE_TRACE(pfnRegisterTutorMessageShown, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-int GetTimesTutorMessageShown(int mid) {
+FORCE_STACK_ALIGN int GetTimesTutorMessageShown(int mid) {
 	ENGINE_TRACE(pfnGetTimesTutorMessageShown, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+FORCE_STACK_ALIGN void ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	ENGINE_TRACE(pfnProcessTutorMessageDecayBuffer, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+FORCE_STACK_ALIGN void ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	ENGINE_TRACE(pfnConstructTutorMessageDecayBuffer, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ResetTutorMessageDecayData(void) {
+FORCE_STACK_ALIGN void ResetTutorMessageDecayData(void) {
 	ENGINE_TRACE(pfnResetTutorMessageDecayData, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
@@ -1070,7 +1070,7 @@ enginefuncs_t meta_engfuncs = {
 	EngCheckParm,					// pfnEngCheckParm()
 };
 
-C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, 
 		int *interfaceVersion) 
 {
 	LOG_DEVELOPER(PLID, "called: GetEngineFunctions; version=%d", 

--- a/trace_plugin/engine_api_post.cpp
+++ b/trace_plugin/engine_api_post.cpp
@@ -46,78 +46,78 @@
 #include "log_plugin.h"
 
 
-int PrecacheModel_Post(char *s) {
+FORCE_STACK_ALIGN int PrecacheModel_Post(char *s) {
 	ENGINE_TRACE(pfnPrecacheModel, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int PrecacheSound_Post(char *s) {
+FORCE_STACK_ALIGN int PrecacheSound_Post(char *s) {
 	ENGINE_TRACE(pfnPrecacheSound, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void SetModel_Post(edict_t *e, const char *m) {
+FORCE_STACK_ALIGN void SetModel_Post(edict_t *e, const char *m) {
 	ENGINE_TRACE(pfnSetModel, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int ModelIndex_Post(const char *m) {
+FORCE_STACK_ALIGN int ModelIndex_Post(const char *m) {
 	ENGINE_TRACE(pfnModelIndex, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int ModelFrames_Post(int modelIndex) {
+FORCE_STACK_ALIGN int ModelFrames_Post(int modelIndex) {
 	ENGINE_TRACE(pfnModelFrames, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void SetSize_Post(edict_t *e, const float *rgflMin, const float *rgflMax) {
+FORCE_STACK_ALIGN void SetSize_Post(edict_t *e, const float *rgflMin, const float *rgflMax) {
 	ENGINE_TRACE(pfnSetSize, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangeLevel_Post(char *s1, char *s2) {
+FORCE_STACK_ALIGN void ChangeLevel_Post(char *s1, char *s2) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnChangeLevel, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GetSpawnParms_Post(edict_t *ent) {
+FORCE_STACK_ALIGN void GetSpawnParms_Post(edict_t *ent) {
 	ENGINE_TRACE(pfnGetSpawnParms, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SaveSpawnParms_Post(edict_t *ent) {
+FORCE_STACK_ALIGN void SaveSpawnParms_Post(edict_t *ent) {
 	ENGINE_TRACE(pfnSaveSpawnParms, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-float VecToYaw_Post(const float *rgflVector) {
+FORCE_STACK_ALIGN float VecToYaw_Post(const float *rgflVector) {
 	ENGINE_TRACE(pfnVecToYaw, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-void VecToAngles_Post(const float *rgflVectorIn, float *rgflVectorOut) {
+FORCE_STACK_ALIGN void VecToAngles_Post(const float *rgflVectorIn, float *rgflVectorOut) {
 	ENGINE_TRACE(pfnVecToAngles, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void MoveToOrigin_Post(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
+FORCE_STACK_ALIGN void MoveToOrigin_Post(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
 	ENGINE_TRACE(pfnMoveToOrigin, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangeYaw_Post(edict_t *ent) {
+FORCE_STACK_ALIGN void ChangeYaw_Post(edict_t *ent) {
 	ENGINE_TRACE(pfnChangeYaw, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ChangePitch_Post(edict_t *ent) {
+FORCE_STACK_ALIGN void ChangePitch_Post(edict_t *ent) {
 	ENGINE_TRACE(pfnChangePitch, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-edict_t *FindEntityByString_Post(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
+FORCE_STACK_ALIGN edict_t *FindEntityByString_Post(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
 	edict_t *ed=META_RESULT_ORIG_RET(edict_t *);
 	ENGINE_TRACE(pfnFindEntityByString, P_POST, ("classname=%s netname=%s", 
 				ed ? STRING(ed->v.classname) : "nil",
 				ed ? STRING(ed->v.netname) : "nil"));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int GetEntityIllum_Post(edict_t *pEnt) {
+FORCE_STACK_ALIGN int GetEntityIllum_Post(edict_t *pEnt) {
 	ENGINE_TRACE(pfnGetEntityIllum, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-edict_t *FindEntityInSphere_Post(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
+FORCE_STACK_ALIGN edict_t *FindEntityInSphere_Post(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
 	edict_t *ret;
 	ret=META_RESULT_ORIG_RET(edict_t *);
 	ENGINE_TRACE(pfnFindEntityInSphere, P_POST, ("previous=%s current=%s", 
@@ -125,33 +125,33 @@ edict_t *FindEntityInSphere_Post(edict_t *pEdictStartSearchAfter, const float *o
 				ret ? STRING(ret->v.classname) : "nil"));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *FindClientInPVS_Post(edict_t *pEdict) {
+FORCE_STACK_ALIGN edict_t *FindClientInPVS_Post(edict_t *pEdict) {
 	ENGINE_TRACE(pfnFindClientInPVS, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *EntitiesInPVS_Post(edict_t *pplayer) {
+FORCE_STACK_ALIGN edict_t *EntitiesInPVS_Post(edict_t *pplayer) {
 	ENGINE_TRACE(pfnEntitiesInPVS, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-void MakeVectors_Post(const float *rgflVector) {
+FORCE_STACK_ALIGN void MakeVectors_Post(const float *rgflVector) {
 	ENGINE_TRACE(pfnMakeVectors, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void AngleVectors_Post(const float *rgflVector, float *forward, float *right, float *up) {
+FORCE_STACK_ALIGN void AngleVectors_Post(const float *rgflVector, float *forward, float *right, float *up) {
 	ENGINE_TRACE(pfnAngleVectors, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-edict_t *CreateEntity_Post(void) {
+FORCE_STACK_ALIGN edict_t *CreateEntity_Post(void) {
 	ENGINE_TRACE(pfnCreateEntity, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void RemoveEntity_Post(edict_t *e) {
+FORCE_STACK_ALIGN void RemoveEntity_Post(edict_t *e) {
 	ENGINE_TRACE(pfnRemoveEntity, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-edict_t *CreateNamedEntity_Post(int className) {
+FORCE_STACK_ALIGN edict_t *CreateNamedEntity_Post(int className) {
 	edict_t *ret;
 	ret=META_RESULT_ORIG_RET(edict_t *);
 	ENGINE_TRACE(pfnCreateNamedEntity, P_POST, ("created=%s", 
@@ -159,183 +159,183 @@ edict_t *CreateNamedEntity_Post(int className) {
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-void MakeStatic_Post(edict_t *ent) {
+FORCE_STACK_ALIGN void MakeStatic_Post(edict_t *ent) {
 	ENGINE_TRACE(pfnMakeStatic, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int EntIsOnFloor_Post(edict_t *e) {
+FORCE_STACK_ALIGN int EntIsOnFloor_Post(edict_t *e) {
 	ENGINE_TRACE(pfnEntIsOnFloor, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int DropToFloor_Post(edict_t *e) {
+FORCE_STACK_ALIGN int DropToFloor_Post(edict_t *e) {
 	ENGINE_TRACE(pfnDropToFloor, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int WalkMove_Post(edict_t *ent, float yaw, float dist, int iMode) {
+FORCE_STACK_ALIGN int WalkMove_Post(edict_t *ent, float yaw, float dist, int iMode) {
 	ENGINE_TRACE(pfnWalkMove, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void SetOrigin_Post(edict_t *e, const float *rgflOrigin) {
+FORCE_STACK_ALIGN void SetOrigin_Post(edict_t *e, const float *rgflOrigin) {
 	ENGINE_TRACE(pfnSetOrigin, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void EmitSound_Post(edict_t *entity, int channel, const char *sample, /*int*/float volume, float attenuation, int fFlags, int pitch) {
+FORCE_STACK_ALIGN void EmitSound_Post(edict_t *entity, int channel, const char *sample, /*int*/float volume, float attenuation, int fFlags, int pitch) {
 	ENGINE_TRACE(pfnEmitSound, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void EmitAmbientSound_Post(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
+FORCE_STACK_ALIGN void EmitAmbientSound_Post(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
 	ENGINE_TRACE(pfnEmitAmbientSound, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceLine, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void TraceToss_Post(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceToss_Post(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceToss, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int TraceMonsterHull_Post(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN int TraceMonsterHull_Post(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceMonsterHull, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void TraceHull_Post(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceHull_Post(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceHull, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void TraceModel_Post(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceModel_Post(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceModel, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *TraceTexture_Post(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
+FORCE_STACK_ALIGN const char *TraceTexture_Post(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
 	ENGINE_TRACE(pfnTraceTexture, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void TraceSphere_Post(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
+FORCE_STACK_ALIGN void TraceSphere_Post(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
 	ENGINE_TRACE(pfnTraceSphere, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GetAimVector_Post(edict_t *ent, float speed, float *rgflReturn) {
+FORCE_STACK_ALIGN void GetAimVector_Post(edict_t *ent, float speed, float *rgflReturn) {
 	ENGINE_TRACE(pfnGetAimVector, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ServerCommand_Post(char *str) {
+FORCE_STACK_ALIGN void ServerCommand_Post(char *str) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnServerCommand, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerExecute_Post(void) {
+FORCE_STACK_ALIGN void ServerExecute_Post(void) {
 	ENGINE_TRACE(pfnServerExecute, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void engClientCommand_Post(edict_t *pEdict, char *szFmt, ...) {
+FORCE_STACK_ALIGN void engClientCommand_Post(edict_t *pEdict, char *szFmt, ...) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnClientCommand, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ParticleEffect_Post(const float *org, const float *dir, float color, float count) {
+FORCE_STACK_ALIGN void ParticleEffect_Post(const float *org, const float *dir, float color, float count) {
 	ENGINE_TRACE(pfnParticleEffect, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void LightStyle_Post(int style, char *val) {
+FORCE_STACK_ALIGN void LightStyle_Post(int style, char *val) {
 	ENGINE_TRACE(pfnLightStyle, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int DecalIndex_Post(const char *name) {
+FORCE_STACK_ALIGN int DecalIndex_Post(const char *name) {
 	ENGINE_TRACE(pfnDecalIndex, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int PointContents_Post(const float *rgflVector) {
+FORCE_STACK_ALIGN int PointContents_Post(const float *rgflVector) {
 	ENGINE_TRACE(pfnPointContents, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void MessageBegin_Post(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
+FORCE_STACK_ALIGN void MessageBegin_Post(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
 	if(msg_type > 64)
 		ENGINE_TRACE(pfnMessageBegin, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void MessageEnd_Post(void) {
+FORCE_STACK_ALIGN void MessageEnd_Post(void) {
 	ENGINE_TRACE(pfnMessageEnd, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void WriteByte_Post(int iValue) {
+FORCE_STACK_ALIGN void WriteByte_Post(int iValue) {
 	ENGINE_TRACE(pfnWriteByte, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteChar_Post(int iValue) {
+FORCE_STACK_ALIGN void WriteChar_Post(int iValue) {
 	ENGINE_TRACE(pfnWriteChar, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteShort_Post(int iValue) {
+FORCE_STACK_ALIGN void WriteShort_Post(int iValue) {
 	ENGINE_TRACE(pfnWriteShort, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteLong_Post(int iValue) {
+FORCE_STACK_ALIGN void WriteLong_Post(int iValue) {
 	ENGINE_TRACE(pfnWriteLong, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteAngle_Post(float flValue) {
+FORCE_STACK_ALIGN void WriteAngle_Post(float flValue) {
 	ENGINE_TRACE(pfnWriteAngle, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteCoord_Post(float flValue) {
+FORCE_STACK_ALIGN void WriteCoord_Post(float flValue) {
 	ENGINE_TRACE(pfnWriteCoord, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteString_Post(const char *sz) {
+FORCE_STACK_ALIGN void WriteString_Post(const char *sz) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnWriteString, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void WriteEntity_Post(int iValue) {
+FORCE_STACK_ALIGN void WriteEntity_Post(int iValue) {
 	ENGINE_TRACE(pfnWriteEntity, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void CVarRegister_Post(cvar_t *pCvar) {
+FORCE_STACK_ALIGN void CVarRegister_Post(cvar_t *pCvar) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnCVarRegister, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-float CVarGetFloat_Post(const char *szVarName) {
+FORCE_STACK_ALIGN float CVarGetFloat_Post(const char *szVarName) {
 	ENGINE_TRACE(pfnCVarGetFloat, P_POST, ("cvar=%s val=%f",
 				szVarName, META_RESULT_ORIG_RET(float)));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-const char *CVarGetString_Post(const char *szVarName) {
+FORCE_STACK_ALIGN const char *CVarGetString_Post(const char *szVarName) {
 	const char *val=META_RESULT_ORIG_RET(const char *);
 	ENGINE_TRACE(pfnCVarGetString, P_POST, ("cvar=%s val=%s",
 				szVarName,
 				val ? val : "nil"));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void CVarSetFloat_Post(const char *szVarName, float flValue) {
+FORCE_STACK_ALIGN void CVarSetFloat_Post(const char *szVarName, float flValue) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnCVarSetFloat, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CVarSetString_Post(const char *szVarName, const char *szValue) {
+FORCE_STACK_ALIGN void CVarSetString_Post(const char *szVarName, const char *szValue) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnCVarSetString, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void AlertMessage_Post(ALERT_TYPE atype, char *szFmt, ...) {
+FORCE_STACK_ALIGN void AlertMessage_Post(ALERT_TYPE atype, char *szFmt, ...) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnAlertMessage, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-void EngineFprintf_Post(FILE *pfile, char *szFmt, ...) {
+FORCE_STACK_ALIGN void EngineFprintf_Post(FILE *pfile, char *szFmt, ...) {
 #else 
-void EngineFprintf_Post(void *pfile, char *szFmt, ...) {
+FORCE_STACK_ALIGN void EngineFprintf_Post(void *pfile, char *szFmt, ...) {
 #endif
 	// trace output in Pre
 	ENGINE_TRACE(pfnEngineFprintf, P_POST, (""));
@@ -343,262 +343,262 @@ void EngineFprintf_Post(void *pfile, char *szFmt, ...) {
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-void *PvAllocEntPrivateData_Post(edict_t *pEdict, long cb) {
+FORCE_STACK_ALIGN void *PvAllocEntPrivateData_Post(edict_t *pEdict, long cb) {
 #else
-void *PvAllocEntPrivateData_Post(edict_t *pEdict, int32 cb) {
+FORCE_STACK_ALIGN void *PvAllocEntPrivateData_Post(edict_t *pEdict, int32 cb) {
 #endif
 	ENGINE_TRACE(pfnPvAllocEntPrivateData, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void *PvEntPrivateData_Post(edict_t *pEdict) {
+FORCE_STACK_ALIGN void *PvEntPrivateData_Post(edict_t *pEdict) {
 	ENGINE_TRACE(pfnPvEntPrivateData, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void FreeEntPrivateData_Post(edict_t *pEdict) {
+FORCE_STACK_ALIGN void FreeEntPrivateData_Post(edict_t *pEdict) {
 	ENGINE_TRACE(pfnFreeEntPrivateData, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-const char *SzFromIndex_Post(int iString) {
+FORCE_STACK_ALIGN const char *SzFromIndex_Post(int iString) {
 	ENGINE_TRACE(pfnSzFromIndex, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int AllocString_Post(const char *szValue) {
+FORCE_STACK_ALIGN int AllocString_Post(const char *szValue) {
 	ENGINE_TRACE(pfnAllocString, P_POST, ("str=%s alloc=%d",
 				szValue, META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-struct entvars_s *GetVarsOfEnt_Post(edict_t *pEdict) {
+FORCE_STACK_ALIGN struct entvars_s *GetVarsOfEnt_Post(edict_t *pEdict) {
 	ENGINE_TRACE(pfnGetVarsOfEnt, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *PEntityOfEntOffset_Post(int iEntOffset) {
+FORCE_STACK_ALIGN edict_t *PEntityOfEntOffset_Post(int iEntOffset) {
 	ENGINE_TRACE(pfnPEntityOfEntOffset, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int EntOffsetOfPEntity_Post(const edict_t *pEdict) {
+FORCE_STACK_ALIGN int EntOffsetOfPEntity_Post(const edict_t *pEdict) {
 	ENGINE_TRACE(pfnEntOffsetOfPEntity, P_POST, ("offset=%d", 
 				META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int IndexOfEdict_Post(const edict_t *pEdict) {
+FORCE_STACK_ALIGN int IndexOfEdict_Post(const edict_t *pEdict) {
 	ENGINE_TRACE(pfnIndexOfEdict, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-edict_t *PEntityOfEntIndex_Post(int iEntIndex) {
+FORCE_STACK_ALIGN edict_t *PEntityOfEntIndex_Post(int iEntIndex) {
 	edict_t *ed=META_RESULT_ORIG_RET(edict_t *);
 	ENGINE_TRACE(pfnPEntityOfEntIndex, P_POST, ("classname=%s netname=%s", 
 				ed ? STRING(ed->v.classname) : "nil",
 				ed ? STRING(ed->v.netname) : "nil"));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-edict_t *FindEntityByVars_Post(struct entvars_s *pvars) {
+FORCE_STACK_ALIGN edict_t *FindEntityByVars_Post(struct entvars_s *pvars) {
 	ENGINE_TRACE(pfnFindEntityByVars, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void *GetModelPtr_Post(edict_t *pEdict) {
+FORCE_STACK_ALIGN void *GetModelPtr_Post(edict_t *pEdict) {
 	ENGINE_TRACE(pfnGetModelPtr, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int RegUserMsg_Post(const char *pszName, int iSize) {
+FORCE_STACK_ALIGN int RegUserMsg_Post(const char *pszName, int iSize) {
 	int ret;
 	ENGINE_TRACE(pfnRegUserMsg, P_POST, ("msg=%s, id=%d, size=%d", 
 				pszName, META_RESULT_ORIG_RET(int), iSize));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void AnimationAutomove_Post(const edict_t *pEdict, float flTime) {
+FORCE_STACK_ALIGN void AnimationAutomove_Post(const edict_t *pEdict, float flTime) {
 	ENGINE_TRACE(pfnAnimationAutomove, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void GetBonePosition_Post(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
+FORCE_STACK_ALIGN void GetBonePosition_Post(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
 	ENGINE_TRACE(pfnGetBonePosition, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-unsigned long FunctionFromName_Post( const char *pName ) {
+FORCE_STACK_ALIGN unsigned long FunctionFromName_Post( const char *pName ) {
 #else
-uint32 FunctionFromName_Post( const char *pName ) {
+FORCE_STACK_ALIGN uint32 FunctionFromName_Post( const char *pName ) {
 #endif
 	ENGINE_TRACE(pfnFunctionFromName, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0UL);
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-const char *NameForFunction_Post( unsigned long function ) {
+FORCE_STACK_ALIGN const char *NameForFunction_Post( unsigned long function ) {
 #else
-const char *NameForFunction_Post( uint32 function ) {
+FORCE_STACK_ALIGN const char *NameForFunction_Post( uint32 function ) {
 #endif
 	ENGINE_TRACE(pfnNameForFunction, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
 //! JOHN: engine callbacks so game DLL can print messages to individual clients
-void ClientPrintf_Post( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
+FORCE_STACK_ALIGN void ClientPrintf_Post( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnClientPrintf, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void ServerPrint_Post( const char *szMsg ) {
+FORCE_STACK_ALIGN void ServerPrint_Post( const char *szMsg ) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnServerPrint, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! these 3 added so game DLL can easily access client 'cmd' strings
-const char *Cmd_Args_Post( void ) {
+FORCE_STACK_ALIGN const char *Cmd_Args_Post( void ) {
 	ENGINE_TRACE(pfnCmd_Args, P_POST, ("args=%s", 
 				META_RESULT_ORIG_RET(char *)));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-const char *Cmd_Argv_Post( int argc ) {
+FORCE_STACK_ALIGN const char *Cmd_Argv_Post( int argc ) {
 	ENGINE_TRACE(pfnCmd_Argv, P_POST, ("arg=%s", 
 				META_RESULT_ORIG_RET(char *)));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-int Cmd_Argc_Post( void ) {
+FORCE_STACK_ALIGN int Cmd_Argc_Post( void ) {
 	ENGINE_TRACE(pfnCmd_Argc, P_POST, ("argc=%d", 
 				META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void GetAttachment_Post(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
+FORCE_STACK_ALIGN void GetAttachment_Post(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
 	ENGINE_TRACE(pfnGetAttachment, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void CRC32_Init_Post(CRC32_t *pulCRC) {
+FORCE_STACK_ALIGN void CRC32_Init_Post(CRC32_t *pulCRC) {
 	ENGINE_TRACE(pfnCRC32_Init, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CRC32_ProcessBuffer_Post(CRC32_t *pulCRC, void *p, int len) {
+FORCE_STACK_ALIGN void CRC32_ProcessBuffer_Post(CRC32_t *pulCRC, void *p, int len) {
 	ENGINE_TRACE(pfnCRC32_ProcessBuffer, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void CRC32_ProcessByte_Post(CRC32_t *pulCRC, unsigned char ch) {
+FORCE_STACK_ALIGN void CRC32_ProcessByte_Post(CRC32_t *pulCRC, unsigned char ch) {
 	ENGINE_TRACE(pfnCRC32_ProcessByte, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-CRC32_t CRC32_Final_Post(CRC32_t pulCRC) {
+FORCE_STACK_ALIGN CRC32_t CRC32_Final_Post(CRC32_t pulCRC) {
 	ENGINE_TRACE(pfnCRC32_Final, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-long RandomLong_Post(long lLow, long lHigh) {
+FORCE_STACK_ALIGN long RandomLong_Post(long lLow, long lHigh) {
 #else
-int32 RandomLong_Post(int32 lLow, int32 lHigh) {
+FORCE_STACK_ALIGN int32 RandomLong_Post(int32 lLow, int32 lHigh) {
 #endif
 	ENGINE_TRACE(pfnRandomLong, P_POST, ("random=%ld", 
 				META_RESULT_ORIG_RET(long)));
 	RETURN_META_VALUE(MRES_IGNORED, 0L);
 }
-float RandomFloat_Post(float flLow, float flHigh) {
+FORCE_STACK_ALIGN float RandomFloat_Post(float flLow, float flHigh) {
 	ENGINE_TRACE(pfnRandomFloat, P_POST, ("random=%f", 
 				META_RESULT_ORIG_RET(float)));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
 
-void SetView_Post(const edict_t *pClient, const edict_t *pViewent ) {
+FORCE_STACK_ALIGN void SetView_Post(const edict_t *pClient, const edict_t *pViewent ) {
 	ENGINE_TRACE(pfnSetView, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-float Time_Post( void ) {
+FORCE_STACK_ALIGN float Time_Post( void ) {
 	ENGINE_TRACE(pfnTime, P_POST, ("time=%f", 
 				META_RESULT_ORIG_RET(float)));
 	RETURN_META_VALUE(MRES_IGNORED, 0.0);
 }
-void CrosshairAngle_Post(const edict_t *pClient, float pitch, float yaw) {
+FORCE_STACK_ALIGN void CrosshairAngle_Post(const edict_t *pClient, float pitch, float yaw) {
 	ENGINE_TRACE(pfnCrosshairAngle, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-byte *LoadFileForMe_Post(char *filename, int *pLength) {
+FORCE_STACK_ALIGN byte *LoadFileForMe_Post(char *filename, int *pLength) {
 	ENGINE_TRACE(pfnLoadFileForMe, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void FreeFile_Post(void *buffer) {
+FORCE_STACK_ALIGN void FreeFile_Post(void *buffer) {
 	ENGINE_TRACE(pfnFreeFile, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
 //! trigger_endsection
-void EndSection_Post(const char *pszSectionName) {
+FORCE_STACK_ALIGN void EndSection_Post(const char *pszSectionName) {
 	ENGINE_TRACE(pfnEndSection, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int CompareFileTime_Post(char *filename1, char *filename2, int *iCompare) {
+FORCE_STACK_ALIGN int CompareFileTime_Post(char *filename1, char *filename2, int *iCompare) {
 	ENGINE_TRACE(pfnCompareFileTime, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void GetGameDir_Post(char *szGetGameDir) {
+FORCE_STACK_ALIGN void GetGameDir_Post(char *szGetGameDir) {
 	ENGINE_TRACE(pfnGetGameDir, P_POST, ("gamedir=%s", szGetGameDir));
 	RETURN_META(MRES_IGNORED);
 }
-void Cvar_RegisterVariable_Post(cvar_t *variable) {
+FORCE_STACK_ALIGN void Cvar_RegisterVariable_Post(cvar_t *variable) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnCvar_RegisterVariable, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void FadeClientVolume_Post(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
+FORCE_STACK_ALIGN void FadeClientVolume_Post(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
 	ENGINE_TRACE(pfnFadeClientVolume, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SetClientMaxspeed_Post(const edict_t *pEdict, float fNewMaxspeed) {
+FORCE_STACK_ALIGN void SetClientMaxspeed_Post(const edict_t *pEdict, float fNewMaxspeed) {
 	ENGINE_TRACE(pfnSetClientMaxspeed, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 //! returns NULL if fake client can't be created
-edict_t * CreateFakeClient_Post(const char *netname) {
+FORCE_STACK_ALIGN edict_t * CreateFakeClient_Post(const char *netname) {
 	ENGINE_TRACE(pfnCreateFakeClient, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void RunPlayerMove_Post(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
+FORCE_STACK_ALIGN void RunPlayerMove_Post(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
 	ENGINE_TRACE(pfnRunPlayerMove, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int NumberOfEntities_Post(void) {
+FORCE_STACK_ALIGN int NumberOfEntities_Post(void) {
 	ENGINE_TRACE(pfnNumberOfEntities, P_POST, ("num=%d", 
 				META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
 //! passing in NULL gets the serverinfo
-char *GetInfoKeyBuffer_Post(edict_t *e) {
+FORCE_STACK_ALIGN char *GetInfoKeyBuffer_Post(edict_t *e) {
 	ENGINE_TRACE(pfnGetInfoKeyBuffer, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-char *InfoKeyValue_Post(char *infobuffer, char *key) {
+FORCE_STACK_ALIGN char *InfoKeyValue_Post(char *infobuffer, char *key) {
 	ENGINE_TRACE(pfnInfoKeyValue, P_POST, ("value=%s", 
 				META_RESULT_ORIG_RET(char *)));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void SetKeyValue_Post(char *infobuffer, char *key, char *value) {
+FORCE_STACK_ALIGN void SetKeyValue_Post(char *infobuffer, char *key, char *value) {
 	ENGINE_TRACE(pfnSetKeyValue, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void SetClientKeyValue_Post(int clientIndex, char *infobuffer, char *key, char *value) {
+FORCE_STACK_ALIGN void SetClientKeyValue_Post(int clientIndex, char *infobuffer, char *key, char *value) {
 	ENGINE_TRACE(pfnSetClientKeyValue, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-int IsMapValid_Post(char *filename) {
+FORCE_STACK_ALIGN int IsMapValid_Post(char *filename) {
 	ENGINE_TRACE(pfnIsMapValid, P_POST, ("file=%s, val=%d",
 				filename, META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void StaticDecal_Post( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
+FORCE_STACK_ALIGN void StaticDecal_Post( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
 	ENGINE_TRACE(pfnStaticDecal, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int PrecacheGeneric_Post(char *s) {
+FORCE_STACK_ALIGN int PrecacheGeneric_Post(char *s) {
 	ENGINE_TRACE(pfnPrecacheGeneric, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 //! returns the server assigned userid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-int GetPlayerUserId_Post(edict_t *e ) {
+FORCE_STACK_ALIGN int GetPlayerUserId_Post(edict_t *e ) {
 	edict_t *ed = e;
 	int userid=META_RESULT_ORIG_RET(int);
 	ENGINE_TRACE(pfnGetPlayerUserId, P_POST, ("netname=%s userid=%d",
@@ -612,18 +612,18 @@ void BuildSoundMsg_Post(edict_t *entity, int channel, const char *sample, /*int*
 	RETURN_META(MRES_IGNORED);
 }
 //! is this a dedicated server?
-int IsDedicatedServer_Post(void) {
+FORCE_STACK_ALIGN int IsDedicatedServer_Post(void) {
 	ENGINE_TRACE(pfnIsDedicatedServer, P_POST, ("val=%d",
 				META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-cvar_t *CVarGetPointer_Post(const char *szVarName) {
+FORCE_STACK_ALIGN cvar_t *CVarGetPointer_Post(const char *szVarName) {
 	// output in Pre
 	ENGINE_TRACE(pfnCVarGetPointer, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 //! returns the server assigned WONid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-unsigned int GetPlayerWONId_Post(edict_t *e) {
+FORCE_STACK_ALIGN unsigned int GetPlayerWONId_Post(edict_t *e) {
 	edict_t *ed = e;
 	unsigned int wonid=META_RESULT_ORIG_RET(unsigned int);
 	ENGINE_TRACE(pfnGetPlayerWONId, P_POST, ("netname=%s wonid=%u",
@@ -633,23 +633,23 @@ unsigned int GetPlayerWONId_Post(edict_t *e) {
 }
 
 //! YWB 8/1/99 TFF Physics additions
-void Info_RemoveKey_Post( char *s, const char *key ) {
+FORCE_STACK_ALIGN void Info_RemoveKey_Post( char *s, const char *key ) {
 	ENGINE_TRACE(pfnInfo_RemoveKey, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetPhysicsKeyValue_Post( const edict_t *pClient, const char *key ) {
+FORCE_STACK_ALIGN const char *GetPhysicsKeyValue_Post( const edict_t *pClient, const char *key ) {
 	ENGINE_TRACE(pfnGetPhysicsKeyValue, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-void SetPhysicsKeyValue_Post( const edict_t *pClient, const char *key, const char *value ) {
+FORCE_STACK_ALIGN void SetPhysicsKeyValue_Post( const edict_t *pClient, const char *key, const char *value ) {
 	ENGINE_TRACE(pfnSetPhysicsKeyValue, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-const char *GetPhysicsInfoString_Post( const edict_t *pClient ) {
+FORCE_STACK_ALIGN const char *GetPhysicsInfoString_Post( const edict_t *pClient ) {
 	ENGINE_TRACE(pfnGetPhysicsInfoString, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-unsigned short PrecacheEvent_Post( int type, const char *psz ) {
+FORCE_STACK_ALIGN unsigned short PrecacheEvent_Post( int type, const char *psz ) {
 	ENGINE_TRACE(pfnPrecacheEvent, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0U);
 }
@@ -659,64 +659,64 @@ void PlaybackEvent_Post( int flags, const edict_t *pInvoker, unsigned short even
 	RETURN_META(MRES_IGNORED);
 }
 
-unsigned char *SetFatPVS_Post( float *org ) {
+FORCE_STACK_ALIGN unsigned char *SetFatPVS_Post( float *org ) {
 	ENGINE_TRACE(pfnSetFatPVS, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
-unsigned char *SetFatPAS_Post( float *org ) {
+FORCE_STACK_ALIGN unsigned char *SetFatPAS_Post( float *org ) {
 	ENGINE_TRACE(pfnSetFatPAS, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int CheckVisibility_Post( const edict_t *entity, unsigned char *pset ) {
+FORCE_STACK_ALIGN int CheckVisibility_Post( const edict_t *entity, unsigned char *pset ) {
 	ENGINE_TRACE(pfnCheckVisibility, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void DeltaSetField_Post( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN void DeltaSetField_Post( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaSetField, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaUnsetField_Post( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN void DeltaUnsetField_Post( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaUnsetField, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaAddEncoder_Post( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
+FORCE_STACK_ALIGN void DeltaAddEncoder_Post( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
 	ENGINE_TRACE(pfnDeltaAddEncoder, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-int GetCurrentPlayer_Post( void ) {
+FORCE_STACK_ALIGN int GetCurrentPlayer_Post( void ) {
 	ENGINE_TRACE(pfnGetCurrentPlayer, P_POST, ("val=%d",
 				META_RESULT_ORIG_RET(int)));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int CanSkipPlayer_Post( const edict_t *player ) {
+FORCE_STACK_ALIGN int CanSkipPlayer_Post( const edict_t *player ) {
 	ENGINE_TRACE(pfnCanSkipPlayer, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-int DeltaFindField_Post( struct delta_s *pFields, const char *fieldname ) {
+FORCE_STACK_ALIGN int DeltaFindField_Post( struct delta_s *pFields, const char *fieldname ) {
 	ENGINE_TRACE(pfnDeltaFindField, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void DeltaSetFieldByIndex_Post( struct delta_s *pFields, int fieldNumber ) {
+FORCE_STACK_ALIGN void DeltaSetFieldByIndex_Post( struct delta_s *pFields, int fieldNumber ) {
 	ENGINE_TRACE(pfnDeltaSetFieldByIndex, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
-void DeltaUnsetFieldByIndex_Post( struct delta_s *pFields, int fieldNumber ) {
+FORCE_STACK_ALIGN void DeltaUnsetFieldByIndex_Post( struct delta_s *pFields, int fieldNumber ) {
 	ENGINE_TRACE(pfnDeltaUnsetFieldByIndex, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void SetGroupMask_Post( int mask, int op ) {
+FORCE_STACK_ALIGN void SetGroupMask_Post( int mask, int op ) {
 	ENGINE_TRACE(pfnSetGroupMask, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-int engCreateInstancedBaseline_Post( int classname, struct entity_state_s *baseline ) {
+FORCE_STACK_ALIGN int engCreateInstancedBaseline_Post( int classname, struct entity_state_s *baseline ) {
 	ENGINE_TRACE(pfnCreateInstancedBaseline, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
-void Cvar_DirectSet_Post( struct cvar_s *var, char *value ) {
+FORCE_STACK_ALIGN void Cvar_DirectSet_Post( struct cvar_s *var, char *value ) {
 	ENGINE_TRACE(pfnCvar_DirectSet, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
@@ -724,13 +724,13 @@ void Cvar_DirectSet_Post( struct cvar_s *var, char *value ) {
 //! Forces the client and server to be running with the same version of the specified file
 //!( e.g., a player model ).
 //! Calling this has no effect in single player
-void ForceUnmodified_Post( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
+FORCE_STACK_ALIGN void ForceUnmodified_Post( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnForceUnmodified, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void GetPlayerStats_Post( const edict_t *pClient, int *ping, int *packet_loss ) {
+FORCE_STACK_ALIGN void GetPlayerStats_Post( const edict_t *pClient, int *ping, int *packet_loss ) {
 	const edict_t *ed=pClient;
 	ENGINE_TRACE(pfnGetPlayerStats, P_POST, 
 			("netname=%s ping=%d packet_loss=%d",
@@ -740,7 +740,7 @@ void GetPlayerStats_Post( const edict_t *pClient, int *ping, int *packet_loss ) 
 	RETURN_META(MRES_IGNORED);
 }
 
-void AddServerCommand_Post( char *cmd_name, void (*function) (void) ) {
+FORCE_STACK_ALIGN void AddServerCommand_Post( char *cmd_name, void (*function) (void) ) {
 	// trace output in Pre
 	ENGINE_TRACE(pfnAddServerCommand, P_POST, (""));
 	RETURN_META(MRES_IGNORED);
@@ -750,18 +750,18 @@ void AddServerCommand_Post( char *cmd_name, void (*function) (void) ) {
 
 //! For voice communications, set which clients hear eachother.
 //! NOTE: these functions take player entity indices (starting at 1).
-qboolean Voice_GetClientListening_Post(int iReceiver, int iSender) {
+FORCE_STACK_ALIGN qboolean Voice_GetClientListening_Post(int iReceiver, int iSender) {
 	ENGINE_TRACE(pfnVoice_GetClientListening, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, false);
 }
-qboolean Voice_SetClientListening_Post(int iReceiver, int iSender, qboolean bListen) {
+FORCE_STACK_ALIGN qboolean Voice_SetClientListening_Post(int iReceiver, int iSender, qboolean bListen) {
 	ENGINE_TRACE(pfnVoice_SetClientListening, P_POST, (""));
 	RETURN_META_VALUE(MRES_IGNORED, false);
 }
 
 // Added for HL 1109 (no SDK update):
 
-const char *GetPlayerAuthId_Post(edict_t *e) {
+FORCE_STACK_ALIGN const char *GetPlayerAuthId_Post(edict_t *e) {
 	edict_t *ed = e;
 	const char *authid=META_RESULT_ORIG_RET(const char *);
 	ENGINE_TRACE(pfnGetPlayerAuthId, P_POST, ("netname=%s authid=%s",
@@ -772,67 +772,67 @@ const char *GetPlayerAuthId_Post(edict_t *e) {
 
 // Added 2003/11/10 (no SDK update):
 
-sequenceEntry_s *SequenceGet_Post(const char* fileName, const char* entryName) {
+FORCE_STACK_ALIGN sequenceEntry_s *SequenceGet_Post(const char* fileName, const char* entryName) {
 	// trace output in Post
 	ENGINE_TRACE(pfnSequenceGet, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-sentenceEntry_s *SequencePickSentence_Post(const char* groupName, int pickMethod, int *picked) {
+FORCE_STACK_ALIGN sentenceEntry_s *SequencePickSentence_Post(const char* groupName, int pickMethod, int *picked) {
 	// trace output in Post
 	ENGINE_TRACE(pfnSequencePickSentence, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
 
-int GetFileSize_Post(char *filename) {
+FORCE_STACK_ALIGN int GetFileSize_Post(char *filename) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetFileSize, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-unsigned int GetApproxWavePlayLen_Post(const char *filepath) {
+FORCE_STACK_ALIGN unsigned int GetApproxWavePlayLen_Post(const char *filepath) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetApproxWavePlayLen, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int IsCareerMatch_Post(void) {
+FORCE_STACK_ALIGN int IsCareerMatch_Post(void) {
 	// trace output in Post
 	ENGINE_TRACE(pfnIsCareerMatch, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-int GetLocalizedStringLength_Post(const char *label) {
+FORCE_STACK_ALIGN int GetLocalizedStringLength_Post(const char *label) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetLocalizedStringLength, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void RegisterTutorMessageShown_Post(int mid) {
+FORCE_STACK_ALIGN void RegisterTutorMessageShown_Post(int mid) {
 	// trace output in Post
 	ENGINE_TRACE(pfnRegisterTutorMessageShown, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-int GetTimesTutorMessageShown_Post(int mid) {
+FORCE_STACK_ALIGN int GetTimesTutorMessageShown_Post(int mid) {
 	// trace output in Post
 	ENGINE_TRACE(pfnGetTimesTutorMessageShown, P_PRE, (""));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void ProcessTutorMessageDecayBuffer_Post(int *buffer, int bufferLength) {
+FORCE_STACK_ALIGN void ProcessTutorMessageDecayBuffer_Post(int *buffer, int bufferLength) {
 	// trace output in Post
 	ENGINE_TRACE(pfnProcessTutorMessageDecayBuffer, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ConstructTutorMessageDecayBuffer_Post(int *buffer, int bufferLength) {
+FORCE_STACK_ALIGN void ConstructTutorMessageDecayBuffer_Post(int *buffer, int bufferLength) {
 	// trace output in Post
 	ENGINE_TRACE(pfnConstructTutorMessageDecayBuffer, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
 }
 
-void ResetTutorMessageDecayData_Post(void) {
+FORCE_STACK_ALIGN void ResetTutorMessageDecayData_Post(void) {
 	// trace output in Post
 	ENGINE_TRACE(pfnResetTutorMessageDecayData, P_PRE, (""));
 	RETURN_META(MRES_IGNORED);
@@ -840,7 +840,7 @@ void ResetTutorMessageDecayData_Post(void) {
 
 // Added 2005-08-11 (no SDK update):
 
-void QueryClientCvarValue_Post(const edict_t *pEdict, const char *cvar) {
+FORCE_STACK_ALIGN void QueryClientCvarValue_Post(const edict_t *pEdict, const char *cvar) {
 	// trace output in Post
 	ENGINE_TRACE(pfnQueryClientCvarValue, P_POST, ("queried=%s",cvar?cvar:"nil"));
 	RETURN_META(MRES_IGNORED);
@@ -848,7 +848,7 @@ void QueryClientCvarValue_Post(const edict_t *pEdict, const char *cvar) {
 
 // Added 2005-11-22 (no SDK update):
 
-void QueryClientCvarValue2_Post(const edict_t *pEdict, const char *cvar, int requestID) {
+FORCE_STACK_ALIGN void QueryClientCvarValue2_Post(const edict_t *pEdict, const char *cvar, int requestID) {
 	// trace output in Post
 	ENGINE_TRACE(pfnQueryClientCvarValue2, P_POST, ("queried=%s, requestID=%d",cvar?cvar:"nil",requestID));
 	RETURN_META(MRES_IGNORED);
@@ -856,7 +856,7 @@ void QueryClientCvarValue2_Post(const edict_t *pEdict, const char *cvar, int req
 
 // Added 2009-06-17 (no SDK update):
 
-int EngCheckParm_Post(const char *pchCmdLineToken, char **pchNextVal) {
+FORCE_STACK_ALIGN int EngCheckParm_Post(const char *pchCmdLineToken, char **pchNextVal) {
 	// trace output in Post
 	ENGINE_TRACE(pfnEngCheckParm, P_POST, ("token=%s, nextval=%s",pchCmdLineToken?pchCmdLineToken:"nil",pchNextVal?*pchNextVal:"nil"));
 	RETURN_META_VALUE(MRES_IGNORED, 0);
@@ -1073,7 +1073,7 @@ enginefuncs_t meta_engfuncs_post = {
 	EngCheckParm_Post,					// pfnEngCheckParm()
 };
 
-C_DLLEXPORT int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion ) 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion ) 
 {
 	LOG_DEVELOPER(PLID, "called: GetEngineFunctions_Post; version=%d", *interfaceVersion);
 	if(!pengfuncsFromEngine) {

--- a/trace_plugin/h_export.cpp
+++ b/trace_plugin/h_export.cpp
@@ -39,7 +39,7 @@ globalvars_t  *gpGlobals;
 // Receive engine function table from engine.
 // This appears to be the _first_ DLL routine called by the engine, so we
 // do some setup operations here.
-void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
+C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
 {
 	memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
 	gpGlobals = pGlobals;

--- a/trace_plugin/meta_api.cpp
+++ b/trace_plugin/meta_api.cpp
@@ -75,11 +75,11 @@ mutil_funcs_t *gpMetaUtilFuncs;		// metamod utility functions
 //  ifvers			(given) interface_version metamod is using
 //  pPlugInfo		(requested) struct with info about plugin
 //  pMetaUtilFuncs	(given) table of utility functions provided by metamod
-C_DLLEXPORT int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
-		mutil_funcs_t *pMetaUtilFuncs) 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
+		mutil_funcs_t *pMetaUtilFuncs)
 {
 	if ((int) CVAR_GET_FLOAT("developer") != 0)
-		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n", 
+		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n",
 				Plugin_info.logtag, ifvers, Plugin_info.ifvers);
 
 	// Check for valid pMetaUtilFuncs before we continue.
@@ -127,7 +127,7 @@ C_DLLEXPORT int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
 //  pFunctionTable	(requested) table of function tables this plugin catches
 //  pMGlobals		(given) global vars from metamod
 //  pGamedllFuncs	(given) copy of function tables from game dll
-C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable,
 		meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
 {
 	if(now > Plugin_info.loadable) {
@@ -159,7 +159,7 @@ C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable,
 // Metamod detaching plugin from the server.
 // now		(given) current phase, ie during map, etc
 // reason	(given) why detaching (refresh, console unload, forced unload, etc)
-C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
 	if(now > Plugin_info.unloadable && reason != PNL_CMD_FORCED) {
 		LOG_ERROR(PLID, "Can't unload plugin right now");
 		return(FALSE);

--- a/trace_plugin/trace_api.cpp
+++ b/trace_plugin/trace_api.cpp
@@ -86,7 +86,7 @@ void trace_init(void) {
 }
 
 // Parse "trace" console command.
-void svr_trace(void) {
+FORCE_STACK_ALIGN void svr_trace(void) {
 	const char *cmd;
 	cmd=CMD_ARGV(1);
 	if(!strcasecmp(cmd, "version"))

--- a/wdmisc_plugin/dll_plugin.cpp
+++ b/wdmisc_plugin/dll_plugin.cpp
@@ -44,7 +44,7 @@
 #include "dll_plugin.h"
 #include "log_plugin.h"
 
-void wd_ServerDeactivate( void ) {
+FORCE_STACK_ALIGN void wd_ServerDeactivate( void ) {
 	bounce_check();
 	RETURN_META(MRES_HANDLED);
 }
@@ -113,7 +113,7 @@ static DLL_FUNCTIONS gFunctionTable =
 	NULL,						//! pfnAllowLagCompensation()
 };
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable,
 		int *interfaceVersion)
 {
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI2; version=%d", *interfaceVersion);

--- a/wdmisc_plugin/engine_api.cpp
+++ b/wdmisc_plugin/engine_api.cpp
@@ -45,7 +45,7 @@
 
 enginefuncs_t meta_engfuncs;
 
-C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, 
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine,
 		int *interfaceVersion) 
 {
 	LOG_DEVELOPER(PLID, "called: GetEngineFunctions; version=%d", 

--- a/wdmisc_plugin/h_export.cpp
+++ b/wdmisc_plugin/h_export.cpp
@@ -39,7 +39,7 @@ globalvars_t  *gpGlobals;
 // Receive engine function table from engine.
 // This appears to be the _first_ DLL routine called by the engine, so we
 // do some setup operations here.
-void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
+C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
 {
 	memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
 	gpGlobals = pGlobals;

--- a/wdmisc_plugin/meta_api.cpp
+++ b/wdmisc_plugin/meta_api.cpp
@@ -75,11 +75,11 @@ mutil_funcs_t *gpMetaUtilFuncs;		// metamod utility functions
 //  ifvers			(given) interface_version metamod is using
 //  pPlugInfo		(requested) struct with info about plugin
 //  pMetaUtilFuncs	(given) table of utility functions provided by metamod
-C_DLLEXPORT int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
-		mutil_funcs_t *pMetaUtilFuncs) 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
+		mutil_funcs_t *pMetaUtilFuncs)
 {
 	if ((int) CVAR_GET_FLOAT("developer") != 0)
-		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n", 
+		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n",
 				Plugin_info.logtag, ifvers, Plugin_info.ifvers);
 
 	// Check for valid pMetaUtilFuncs before we continue.
@@ -127,7 +127,7 @@ C_DLLEXPORT int Meta_Query(char *ifvers, plugin_info_t **pPlugInfo,
 //  pFunctionTable	(requested) table of function tables this plugin catches
 //  pMGlobals		(given) global vars from metamod
 //  pGamedllFuncs	(given) copy of function tables from game dll
-C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, 
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable,
 		meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
 {
 	if(now > Plugin_info.loadable) {
@@ -159,7 +159,7 @@ C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable,
 // Metamod detaching plugin from the server.
 // now		(given) current phase, ie during map, etc
 // reason	(given) why detaching (refresh, console unload, forced unload, etc)
-C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
 	if(now > Plugin_info.unloadable && reason != PNL_CMD_FORCED) {
 		LOG_ERROR(PLID, "Can't unload plugin right now");
 		return(FALSE);

--- a/wdmisc_plugin/wdmisc.cpp
+++ b/wdmisc_plugin/wdmisc.cpp
@@ -115,7 +115,7 @@ void do_my_getengfuncs(void) {
 // on, which makes the code a bit less readable than doing just a "strstr"
 // on the log line. 
 
-void wd_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
+FORCE_STACK_ALIGN void wd_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	va_list ap;
 	static char buf[MAX_LOGMSG_LEN];
 	char *cp, *ep;
@@ -177,7 +177,7 @@ void wd_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	RETURN_META(MRES_HANDLED);
 }
 
-void wd_msglist(void) {
+FORCE_STACK_ALIGN void wd_msglist(void) {
 	int i, size;
 	const char *cp;
 	LOG_CONSOLE(PLID, "registered user msgs:");
@@ -188,7 +188,7 @@ void wd_msglist(void) {
 	}
 }
 
-void wd_msgid(void) {
+FORCE_STACK_ALIGN void wd_msgid(void) {
 	const char *msgname;
 	int id;
 	msgname=CMD_ARGV(1);
@@ -199,7 +199,7 @@ void wd_msgid(void) {
 		LOG_CONSOLE(PLID, "msg not found: %s", msgname);
 }
 
-void wd_testit(void) {
+FORCE_STACK_ALIGN void wd_testit(void) {
 	cvar_t *cv;
 	cv=CVAR_GET_POINTER("csguard_version");
 	if(cv)


### PR DESCRIPTION
## Summary

- Add `FORCE_STACK_ALIGN` to all exported and callback functions in trace_plugin, stub_plugin, and wdmisc_plugin, mirroring the metamod fix from cd51ac1
- Add missing `C_DLLEXPORT` on `GiveFnptrsToDll` in all three plugins
- Also annotate functions whose pointers are stored in externally accessible memory (`REG_SVR_COMMAND` handlers, engine function hooks)
- Extend CI `build.yml` to compile stub_plugin and wdmisc_plugin for Linux, Linux-bionic, and Windows cross-compilation

Closes #83

## Test plan

- [x] All three plugins build cleanly with i686-linux-gnu-gcc (optimized)
- [x] All three plugins build cleanly with i686-w64-mingw32-g++ (Windows cross-compile)
- [ ] CI passes on all three build jobs (linux, linux-bionic, windows)