### PR TITLE
trace_plugin: add per-function call counters for API profiling

### DIFF
--- a/trace_plugin/api_info.h
+++ b/trace_plugin/api_info.h
@@ -62,6 +62,8 @@ typedef struct api_info_s {
 	int loglevel;			// level at which to log info about this function
 	api_caller_func_t api_caller;	// argument format/type for single-main-hook-function optimization
 	const char *name;		// string representation of function name
+	unsigned long count_pre;	// pre-hook call counter
+	unsigned long count_post;	// post-hook call counter
 } api_info_t;
 
 

--- a/trace_plugin/trace_api.cpp
+++ b/trace_plugin/trace_api.cpp
@@ -99,6 +99,10 @@ FORCE_STACK_ALIGN void svr_trace(void) {
 		cmd_trace_unset();
 	else if(!strcasecmp(cmd, "list"))
 		cmd_trace_list();
+	else if(!strcasecmp(cmd, "count"))
+		cmd_trace_count();
+	else if(!strcasecmp(cmd, "resetcount"))
+		cmd_trace_resetcount();
 	else {
 		LOG_CONSOLE(PLID, "Unrecognized trace command: %s", cmd);
 		cmd_trace_usage();
@@ -117,7 +121,9 @@ void cmd_trace_usage(void) {
 	LOG_CONSOLE(PLID, "   list dllapi      - list all dllapi routines available for tracing");
 	LOG_CONSOLE(PLID, "   list newapi      - list all newapi routines available for tracing");
 	LOG_CONSOLE(PLID, "   list engine      - list all engine routines available for tracing");
-	LOG_CONSOLE(PLID, "   list all         - list dllapi, neapi, and engine");
+	LOG_CONSOLE(PLID, "   list all         - list dllapi, newapi, and engine");
+	LOG_CONSOLE(PLID, "   count            - show per-function call counts");
+	LOG_CONSOLE(PLID, "   resetcount       - reset all call counters to zero");
 }
 
 // "trace version" console command.
@@ -253,6 +259,73 @@ void cmd_trace_list(void) {
 		LOG_CONSOLE(PLID, "   engine    - list all engine routines available for tracing");
 		LOG_CONSOLE(PLID, "   all       - list dllapi, newapi, engine");
 	}
+}
+
+// "trace count" console command.
+void cmd_trace_count(void) {
+	int n;
+	unsigned long total_pre=0, total_post=0;
+
+	n=0;
+	LOG_CONSOLE(PLID, "DLLAPI call counts (pre / post):");
+	for(api_info_t *routine=&dllapi_info.pfnGameInit; routine->name; routine++) {
+		if(routine->count_pre || routine->count_post) {
+			LOG_CONSOLE(PLID, "  %-35s %10lu / %10lu", routine->name,
+					routine->count_pre, routine->count_post);
+			total_pre+=routine->count_pre;
+			total_post+=routine->count_post;
+			n++;
+		}
+	}
+	if(!n)
+		LOG_CONSOLE(PLID, "  (none)");
+
+	n=0;
+	LOG_CONSOLE(PLID, "NEWAPI call counts (pre / post):");
+	for(api_info_t *routine=&newapi_info.pfnOnFreeEntPrivateData; routine->name; routine++) {
+		if(routine->count_pre || routine->count_post) {
+			LOG_CONSOLE(PLID, "  %-35s %10lu / %10lu", routine->name,
+					routine->count_pre, routine->count_post);
+			total_pre+=routine->count_pre;
+			total_post+=routine->count_post;
+			n++;
+		}
+	}
+	if(!n)
+		LOG_CONSOLE(PLID, "  (none)");
+
+	n=0;
+	LOG_CONSOLE(PLID, "Engine call counts (pre / post):");
+	for(api_info_t *routine=&engine_info.pfnPrecacheModel; routine->name; routine++) {
+		if(routine->count_pre || routine->count_post) {
+			LOG_CONSOLE(PLID, "  %-35s %10lu / %10lu", routine->name,
+					routine->count_pre, routine->count_post);
+			total_pre+=routine->count_pre;
+			total_post+=routine->count_post;
+			n++;
+		}
+	}
+	if(!n)
+		LOG_CONSOLE(PLID, "  (none)");
+
+	LOG_CONSOLE(PLID, "Total: %lu pre, %lu post", total_pre, total_post);
+}
+
+// "trace resetcount" console command.
+void cmd_trace_resetcount(void) {
+	for(api_info_t *routine=&dllapi_info.pfnGameInit; routine->name; routine++) {
+		routine->count_pre=0;
+		routine->count_post=0;
+	}
+	for(api_info_t *routine=&newapi_info.pfnOnFreeEntPrivateData; routine->name; routine++) {
+		routine->count_pre=0;
+		routine->count_post=0;
+	}
+	for(api_info_t *routine=&engine_info.pfnPrecacheModel; routine->name; routine++) {
+		routine->count_pre=0;
+		routine->count_post=0;
+	}
+	LOG_CONSOLE(PLID, "All call counters reset.");
 }
 
 // Set or unset tracing of a given api routine string.  Searches all three

--- a/trace_plugin/trace_api.h
+++ b/trace_plugin/trace_api.h
@@ -45,7 +45,10 @@
 #include "api_info.h"
 
 #define API_TRACE(api_info_table, cvar_trace, api_str, pfnName, post, args) \
-	do { if((cvar_trace->value >= api_info_table.pfnName.loglevel || api_info_table.pfnName.trace) && (unlimit_trace->value || (last_trace_log != time(NULL)))) { \
+	do { \
+		if(post) api_info_table.pfnName.count_post++; \
+		else api_info_table.pfnName.count_pre++; \
+		if((cvar_trace->value >= api_info_table.pfnName.loglevel || api_info_table.pfnName.trace) && (unlimit_trace->value || (last_trace_log != time(NULL)))) { \
 			ALERT(at_logged, "[%s] %s(%d): called: %s%s; %s\n", \
 					Plugin_info.logtag, api_str, \
 					api_info_table.pfnName.loglevel, \
@@ -96,6 +99,8 @@ void cmd_trace_set(void);
 void cmd_trace_unset(void);
 void cmd_trace_show(void);
 void cmd_trace_list(void);
+void cmd_trace_count(void);
+void cmd_trace_resetcount(void);
 
 TRACE_RESULT trace_setflag(const char **pfn_string, mBOOL flagval, const char **api);
 


### PR DESCRIPTION
## Summary

- Add `count_pre`/`count_post` fields to `api_info_t` struct, incremented unconditionally in the `API_TRACE` macro for lightweight call counting
- Add `trace count` console command to dump non-zero call counts grouped by API table (dllapi/newapi/engine)
- Add `trace resetcount` console command to zero all counters
- Verified all SDK functions (`DLL_FUNCTIONS`, `NEW_DLL_FUNCTIONS`, `enginefuncs_t`) are already hooked by trace_plugin

Part 5 of #82 (api_hook re-entry counter) is deferred to a separate metamod-core issue.

## Test plan

- [ ] Build passes on Linux (gcc cross-compile) and Windows (mingw) — verified locally
- [ ] CI builds pass
- [ ] `trace count` shows per-function pre/post counts after server activity
- [ ] `trace resetcount` zeros all counters

Closes #82