### PR TITLE
Replace conditional call_count backup with unconditional meta_globals save/restore

### DIFF
--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -151,17 +151,17 @@ else
 endif
 
 # Compiler (incl. optimization) flags for C++ plugin code
-CCOPT = $(CCO) $(CCOPT_ARCH) -fno-exceptions -fno-rtti
+CCOPT = $(CCO) $(CC_ARCH) -fno-exceptions -fno-rtti
 
 CCO = -O2 -fomit-frame-pointer
 CCO += -flto -fvisibility=hidden
 CCO += -fno-strict-aliasing -fno-strict-overflow
 
-# architecture tuning by target type
+# architecture by target type (applies to all build modes)
 ifeq "$(TARGETTYPE)" "amd64"
-	CCOPT_ARCH =
+	CC_ARCH =
 else
-	CCOPT_ARCH = -march=i686 $(MCPU)=generic -msse2
+	CC_ARCH = -march=i686 $(MCPU)=generic -msse2
 endif
 
 # debugging; halt on warnings
@@ -195,7 +195,7 @@ ifeq "$(OPT)" "opt"
 	OBJDIR_WIN = $(OBJDIR_WIN_OPT)
 else	# debug
 	ODEF = -DOPT_TYPE="\"debugging\""
-	CFLAGS := $(CCDEBUG) $(CFLAGS) $(ODEF)
+	CFLAGS := $(CCDEBUG) $(CC_ARCH) $(CFLAGS) $(ODEF)
 	OBJDIR_LINUX = $(OBJDIR_LINUX_DBG)
 	OBJDIR_WIN = $(OBJDIR_WIN_DBG)
 	DLLS_DIR := $(DLLS_DIR)/debug

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -53,13 +53,24 @@ static const void ** api_info_tables[3] = {
 	(const void**)&newapi_info
 };
 
-// Safety check for metamod-bot-plugin bugfix.
-//  engine_api->pfnRunPlayerMove calls dllapi-functions before it returns.
-//  This causes problems with bots running as metamod plugins, because
-//  metamod assumed that PublicMetaGlobals is free to be used.
-//  With call_count we can fix this by backuping up PublicMetaGlobals if 
-//  it's already being used.
-static unsigned int call_count = 0;
+static inline void copy_meta_globals(meta_globals_t *dst, const meta_globals_t *src) {
+#if defined(__GNUC__) && defined(__SSE2__)
+	typedef char assert_meta_globals_size[sizeof(meta_globals_t) == 20 ? 1 : -1] ATTRIBUTE(unused);
+	__asm__ (
+		"movdqu %[s0], %%xmm0\n\t"
+		"movd   %[s1], %%xmm1\n\t"
+		"movdqu %%xmm0, %[d0]\n\t"
+		"movd   %%xmm1, %[d1]"
+		: [d0] "=m" (*(char (*)[16])dst),
+		  [d1] "=m" (*((int *)dst + 4))
+		: [s0] "m" (*(const char (*)[16])src),
+		  [s1] "m" (*((const int *)src + 4))
+		: "xmm0", "xmm1"
+	);
+#else
+	*dst = *src;
+#endif
+}
 
 // get function pointer from api table by function pointer offset
 inline void * DLLINTERNAL get_api_function(const void * api_table, unsigned int func_offset) {
@@ -80,68 +91,64 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 	void *pfn_routine;
 	int loglevel;
 	const void *api_table;
-	meta_globals_t backup_meta_globals[1];
+	meta_globals_t saved_meta_globals;
 	
 	//passing offset from api wrapper function makes code faster/smaller
 	api_info = get_api_info(api, api_info_offset);
-	
-	//Fix bug with metamod-bot-plugins.
-	if(unlikely(call_count++>0)) {
-		//Backup PublicMetaGlobals.
-		backup_meta_globals[0] = PublicMetaGlobals;
-	}
-	
+
+	// Save meta globals for re-entrant API calls (e.g. pfnRunPlayerMove
+	// calling dllapi functions before returning).
+	copy_meta_globals(&saved_meta_globals, &PublicMetaGlobals);
+
 	//Setup
 	loglevel=api_info->loglevel;
 	mres=MRES_UNSET;
 	status=MRES_UNSET;
 	prev_mres=MRES_UNSET;
 	pfn_routine=NULL;
-	
+
 	//Pre plugin functions
 	prev_mres=MRES_UNSET;
 	for(i=0; likely(i < Plugins->endlist); i++) {
 		iplug=&Plugins->plist[i];
-		
+
 		if(unlikely(iplug->status != PL_RUNNING))
 			continue;
-		
+
 		api_table = iplug->get_api_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
-		
+
 		pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
-		
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
 		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
-		
+
 		// call plugin
 		META_DEBUG(loglevel, ("Calling %s:%s()", iplug->file, api_info->name));
 		api_info->api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
-		
+
 		// plugin's result code
 		mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
-		
+
 		// save this for successive plugins to see
 		prev_mres = mres;
-		
+
 		if(unlikely(mres==MRES_UNSET))
 			META_WARNING("Plugin didn't set meta_result: %s:%s()", iplug->file, api_info->name);
 	}
-	
-	call_count--;
-	
+
 	//Api call
 	if(likely(status!=MRES_SUPERCEDE)) {
 		//get api table
@@ -167,57 +174,52 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 		}
 	} else
 		META_DEBUG(loglevel, ("Skipped (supercede) %s:%s()", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
-	
-	call_count++;
-	
+
 	//Post plugin functions
 	prev_mres=MRES_UNSET;
 	for(i=0; likely(i < Plugins->endlist); i++) {
 		iplug=&Plugins->plist[i];
-		
+
 		if(unlikely(iplug->status != PL_RUNNING))
 			continue;
-		
+
 		api_table = iplug->get_api_post_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
-		
+
 		pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
-		
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
 		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
-		
+
 		// call plugin
 		META_DEBUG(loglevel, ("Calling %s:%s_Post()", iplug->file, api_info->name));
 		api_info->api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
-		
+
 		// plugin's result code
 		mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
-		
+
 		// save this for successive plugins to see
 		prev_mres = mres;
-		
+
 		if(unlikely(mres==MRES_UNSET))
 			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", iplug->file, api_info->name);
 		else if(unlikely(mres==MRES_SUPERCEDE))
 			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", iplug->file, api_info->name);
 	}
 
-	if(unlikely(--call_count>0)) {
-		//Restore backup
-		PublicMetaGlobals = backup_meta_globals[0];
-	}
+	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
 }
 
 // full return typed version of main hook function
@@ -229,17 +231,15 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 	void *pfn_routine;
 	int loglevel;
 	const void *api_table;
-	meta_globals_t backup_meta_globals[1];
-	
+	meta_globals_t saved_meta_globals;
+
 	//passing offset from api wrapper function makes code faster/smaller
 	api_info = get_api_info(api, api_info_offset);
-	
-	//Fix bug with metamod-bot-plugins.
-	if(unlikely(call_count++>0)) {
-		//Backup PublicMetaGlobals.
-		backup_meta_globals[0] = PublicMetaGlobals;
-	}
-	
+
+	// Save meta globals for re-entrant API calls (e.g. pfnRunPlayerMove
+	// calling dllapi functions before returning).
+	copy_meta_globals(&saved_meta_globals, &PublicMetaGlobals);
+
 	//Return class setup
 	class_ret_t dllret=ret_init;
 	class_ret_t override_ret=ret_init;
@@ -306,14 +306,12 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 			META_WARNING("Plugin didn't set meta_result: %s:%s()", iplug->file, api_info->name);
 		}
 	}
-	
-	call_count--;
-	
+
 	//Api call
 	if(likely(status!=MRES_SUPERCEDE)) {
 		//get api table
 		api_table = *api_tables[api];
-		
+
 		if(likely(api_table)) {
 			pfn_routine = get_api_function(api_table, func_offset);
 			if(likely(pfn_routine)) {
@@ -339,9 +337,7 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 		pub_orig_ret = override_ret;
 		PublicMetaGlobals.orig_ret = pub_orig_ret.getptr();
 	}
-	
-	call_count++;
-	
+
 	//Post plugin functions
 	prev_mres=MRES_UNSET;
 	for(i=0; likely(i < Plugins->endlist); i++) {
@@ -398,11 +394,8 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 		}
 	}
 	
-	if(unlikely(--call_count>0)) {
-		//Restore backup
-		PublicMetaGlobals = backup_meta_globals[0];
-	}
-	
+	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
+
 	//return value is passed through ret_init!
 	if(likely(status!=MRES_OVERRIDE)) {
 		return(*(void**)orig_ret.getptr());

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -11,7 +11,7 @@ PARENT_INCLUDES = -I".." -I"../../hlsdk/engine" -I"../../hlsdk/common" \
 TEST_CXXFLAGS = ${CXXFLAGS} ${PARENT_INCLUDES} -D__METAMOD_BUILD__ -DUNITTESTS \
     -Wall -Wno-class-memaccess -Wno-write-strings -Wno-attributes \
     -Wno-format-truncation -fno-strict-aliasing -fno-strict-overflow \
-    -std=gnu++98 \
+    -std=gnu++98 -march=i686 -msse2 \
     $(EXTRA_FLAGS)
 
 %.o: %.cpp


### PR DESCRIPTION
## Summary

- Replace the `call_count` increment/decrement/branch pattern in `main_hook_function` and `main_hook_function_void` with unconditional save/restore of `PublicMetaGlobals`
- Add `copy_meta_globals()` helper using SSE2 inline asm (`movdqu` + `movd`, memory operands — no GPR pressure) with compile-time size assert and plain struct-copy fallback for non-GCC/non-SSE2
- Enable `-march=i686 -msse2` for debug builds and unit tests (was previously only set for optimized builds)

Closes #86

## Perf results

HLDS running HL:DM with Severian's weapon mod, 4 metamod plugins (jk_botti, ghost_mine_block, sc-prot, won2steam), on Intel i3-1115G4 (Tiger Lake). Varrock map, 8 bots, maxplayers 8, 30 minutes, ~3M samples per run. Profiled with `perf record --call-graph lbr -e cycles:u -F 4999 --user-callchains`.

| Function | Pre-PR (master) | Post-PR | Change |
|---|---|---|---|
| `main_hook_function` | 2.39% | 1.78% | **-25.5%** |
| `main_hook_function_void` | 1.51% | 1.52% | ~0% |
| `mm_ShouldCollide` | 0.30% | 0.22% | -27% |
| `mm_StartFrame` | 0.14% | 0.15% | ~0% |
| **Total metamod self-time** | **~4.61%** | **~3.88%** | **-16%** |

The return-value path (`main_hook_function`) benefits most — it has more local state (`class_ret_t` copies), so removing the `call_count` branch and shared mutable static reduces register pressure where it matters. The void path is neutral.

## Test plan

- [x] Linux debug build clean
- [x] Linux optimized build clean
- [x] Win32 cross-compile build clean
- [x] All 36 unit test suites pass
- [x] Verified `movdqu`/`movd` emitted in both debug and opt binaries via objdump
- [x] Live perf test on HLDS server (varrock 8bot 30min)