### PR TITLE
Optimize hook dispatch codegen on i686

### DIFF
--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -72,6 +72,10 @@ static inline void copy_meta_globals(meta_globals_t *dst, const meta_globals_t *
 #endif
 }
 
+static inline const char * api_owner_name(enum_api_t api) {
+	return (api == e_api_engine) ? "engine" : GameDLL.file;
+}
+
 // get function pointer from api table by function pointer offset
 inline void * DLLINTERNAL get_api_function(const void * api_table, unsigned int func_offset) {
 	return(*(void**)((unsigned long)api_table + func_offset));
@@ -84,139 +88,132 @@ inline const api_info_t * DLLINTERNAL get_api_info(enum_api_t api, unsigned int 
 
 // simplified 'void' version of main hook function
 void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
-	const api_info_t *api_info;
-	int i;
-	META_RES mres, status, prev_mres;
-	MPlugin *iplug;
-	void *pfn_routine;
-	int loglevel;
-	const void *api_table;
+	api_info_t api_info;
+	int i, endi;
+	META_RES status;
+	MPlugin *plist;
 	meta_globals_t saved_meta_globals;
-	
+
 	//passing offset from api wrapper function makes code faster/smaller
-	api_info = get_api_info(api, api_info_offset);
+	api_info = *get_api_info(api, api_info_offset);
 
 	// Save meta globals for re-entrant API calls (e.g. pfnRunPlayerMove
 	// calling dllapi functions before returning).
 	copy_meta_globals(&saved_meta_globals, &PublicMetaGlobals);
 
 	//Setup
-	loglevel=api_info->loglevel;
-	mres=MRES_UNSET;
 	status=MRES_UNSET;
-	prev_mres=MRES_UNSET;
-	pfn_routine=NULL;
 
 	//Pre plugin functions
-	prev_mres=MRES_UNSET;
-	for(i=0; likely(i < Plugins->endlist); i++) {
-		iplug=&Plugins->plist[i];
-
-		if(unlikely(iplug->status != PL_RUNNING))
+	PublicMetaGlobals.prev_mres=MRES_UNSET;
+	plist=Plugins->plist;
+	endi=Plugins->endlist;
+	for(i=0; likely(i < endi); i++) {
+		if(unlikely(plist[i].status != PL_RUNNING))
 			continue;
 
-		api_table = iplug->get_api_table(api);
+		const void *api_table = plist[i].get_api_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
 
-		pfn_routine=get_api_function(api_table, func_offset);
+		void *pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
 
+		META_DEBUG(api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
-		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
 
 		// call plugin
-		META_DEBUG(loglevel, ("Calling %s:%s()", iplug->file, api_info->name));
-		api_info->api_caller(pfn_routine, packed_args);
+		api_info.api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
 
 		// plugin's result code
-		mres=PublicMetaGlobals.mres;
+		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
 
 		// save this for successive plugins to see
-		prev_mres = mres;
+		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", iplug->file, api_info->name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plist[i].file, api_info.name);
 	}
 
 	//Api call
 	if(likely(status!=MRES_SUPERCEDE)) {
 		//get api table
-		api_table = *api_tables[api];
-		
+		const void *api_table = *api_tables[api];
+
 		if(likely(api_table)) {
-			pfn_routine = get_api_function(api_table, func_offset);
+			void *pfn_routine = get_api_function(api_table, func_offset);
 			if(likely(pfn_routine)) {
-				META_DEBUG(loglevel, ("Calling %s:%s()", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
-				api_info->api_caller(pfn_routine, packed_args);
+				META_DEBUG(api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
+				api_info.api_caller(pfn_routine, packed_args);
 				API_UNPAUSE_TSC_TRACKING();
 			} else {
 				// don't complain for NULL routines in NEW_DLL_FUNCTIONS
 				if(unlikely(api != e_api_newapi))
-					META_WARNING("Couldn't find api call: %s:%s", (api==e_api_engine)?"engine":GameDLL.file, api_info->name);
+					META_WARNING("Couldn't find api call: %s:%s", api_owner_name(api), api_info.name);
 				status=MRES_UNSET;
 			}
 		} else {
 			// don't complain for NULL NEW_DLL_FUNCTIONS-table
 			if(unlikely(api != e_api_newapi))
-				META_DEBUG(loglevel, ("No api table defined for api call: %s:%s", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
+				META_DEBUG(api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
 			status=MRES_UNSET;
 		}
 	} else
-		META_DEBUG(loglevel, ("Skipped (supercede) %s:%s()", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
+		META_DEBUG(api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
 
 	//Post plugin functions
-	prev_mres=MRES_UNSET;
-	for(i=0; likely(i < Plugins->endlist); i++) {
-		iplug=&Plugins->plist[i];
-
-		if(unlikely(iplug->status != PL_RUNNING))
+	PublicMetaGlobals.prev_mres=MRES_UNSET;
+	plist=Plugins->plist;
+	endi=Plugins->endlist;
+	for(i=0; likely(i < endi); i++) {
+		if(unlikely(plist[i].status != PL_RUNNING))
 			continue;
 
-		api_table = iplug->get_api_post_table(api);
+		const void *api_table = plist[i].get_api_post_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
 
-		pfn_routine=get_api_function(api_table, func_offset);
+		void *pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
 
+		META_DEBUG(api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
-		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
 
 		// call plugin
-		META_DEBUG(loglevel, ("Calling %s:%s_Post()", iplug->file, api_info->name));
-		api_info->api_caller(pfn_routine, packed_args);
+		api_info.api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
 
 		// plugin's result code
-		mres=PublicMetaGlobals.mres;
+		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
 
 		// save this for successive plugins to see
-		prev_mres = mres;
+		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", iplug->file, api_info->name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plist[i].file, api_info.name);
 		else if(unlikely(mres==MRES_SUPERCEDE))
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", iplug->file, api_info->name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plist[i].file, api_info.name);
 	}
 
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
@@ -224,173 +221,163 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 
 // full return typed version of main hook function
 void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
-	const api_info_t *api_info;
-	int i;
-	META_RES mres, status, prev_mres;
-	MPlugin *iplug;
-	void *pfn_routine;
-	int loglevel;
-	const void *api_table;
+	api_info_t api_info;
+	int i, endi;
+	META_RES status;
+	MPlugin *plist;
 	meta_globals_t saved_meta_globals;
+	struct {
+	  class_ret_t orig_ret;
+	  class_ret_t override_ret;
+	} rv, backup_rv;
 
 	//passing offset from api wrapper function makes code faster/smaller
-	api_info = get_api_info(api, api_info_offset);
+	api_info = *get_api_info(api, api_info_offset);
 
 	// Save meta globals for re-entrant API calls (e.g. pfnRunPlayerMove
 	// calling dllapi functions before returning).
 	copy_meta_globals(&saved_meta_globals, &PublicMetaGlobals);
 
 	//Return class setup
-	class_ret_t dllret=ret_init;
-	class_ret_t override_ret=ret_init;
-	class_ret_t pub_override_ret=ret_init;
-	class_ret_t orig_ret=ret_init;
-	class_ret_t pub_orig_ret=ret_init;
-	
+	rv.orig_ret=ret_init;
+	rv.override_ret=ret_init;
+
 	//Setup
-	loglevel=api_info->loglevel;
-	mres=MRES_UNSET;
 	status=MRES_UNSET;
-	prev_mres=MRES_UNSET;
-	pfn_routine=NULL;
-	
+
 	//Pre plugin functions
-	prev_mres=MRES_UNSET;
-	for(i=0; likely(i < Plugins->endlist); i++) {
-		iplug=&Plugins->plist[i];
-		
-		if(unlikely(iplug->status != PL_RUNNING))
+	PublicMetaGlobals.prev_mres = MRES_UNSET;
+	plist=Plugins->plist;
+	endi=Plugins->endlist;
+	for(i=0; likely(i < endi); i++) {
+		if(unlikely(plist[i].status != PL_RUNNING))
 			continue;
-		
-		api_table = iplug->get_api_table(api);
+
+		const void *api_table = plist[i].get_api_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
-		
-		pfn_routine=get_api_function(api_table, func_offset);
+
+		void *pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
-		
+
+		META_DEBUG(api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
-		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
-		pub_orig_ret = orig_ret;
-		PublicMetaGlobals.orig_ret = pub_orig_ret.getptr();
-		if(unlikely(status==MRES_SUPERCEDE)) {
-			pub_override_ret = override_ret;
-			PublicMetaGlobals.override_ret = pub_override_ret.getptr();
-		}
-		
+		PublicMetaGlobals.orig_ret = rv.orig_ret.getptr();
+		PublicMetaGlobals.override_ret = rv.override_ret.getptr();
+
+		backup_rv = rv;
+
 		// call plugin
-		META_DEBUG(loglevel, ("Calling %s:%s()", iplug->file, api_info->name));
-		dllret = class_ret_t(api_info->api_caller(pfn_routine, packed_args));
+		class_ret_t dllret = class_ret_t(api_info.api_caller(pfn_routine, packed_args));
 		API_UNPAUSE_TSC_TRACKING();
-		
+
+		rv = backup_rv;
+
 		// plugin's result code
-		mres=PublicMetaGlobals.mres;
+		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
-		
+
 		// save this for successive plugins to see
-		prev_mres = mres;
-		
+		PublicMetaGlobals.prev_mres = mres;
+
 		if(unlikely(mres==MRES_SUPERCEDE)) {
-			pub_override_ret = dllret;
-			override_ret = dllret;
-		} 
+			rv.override_ret = dllret;
+		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", iplug->file, api_info->name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plist[i].file, api_info.name);
 		}
 	}
 
 	//Api call
 	if(likely(status!=MRES_SUPERCEDE)) {
 		//get api table
-		api_table = *api_tables[api];
+		const void *api_table = *api_tables[api];
 
 		if(likely(api_table)) {
-			pfn_routine = get_api_function(api_table, func_offset);
+			void *pfn_routine = get_api_function(api_table, func_offset);
 			if(likely(pfn_routine)) {
-				META_DEBUG(loglevel, ("Calling %s:%s()", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
-				dllret = class_ret_t(api_info->api_caller(pfn_routine, packed_args));
+				META_DEBUG(api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
+				class_ret_t dllret = class_ret_t(api_info.api_caller(pfn_routine, packed_args));
 				API_UNPAUSE_TSC_TRACKING();
-				orig_ret = dllret;
+				rv.orig_ret = dllret;
 			} else {
 				// don't complain for NULL routines in NEW_DLL_FUNCTIONS
 				if(unlikely(api != e_api_newapi))
-					META_WARNING("Couldn't find api call: %s:%s", (api==e_api_engine)?"engine":GameDLL.file, api_info->name);
+					META_WARNING("Couldn't find api call: %s:%s", api_owner_name(api), api_info.name);
 				status=MRES_UNSET;
 			}
 		} else {
 			// don't complain for NULL NEW_DLL_FUNCTIONS-table
 			if(unlikely(api != e_api_newapi))
-				META_DEBUG(loglevel, ("No api table defined for api call: %s:%s", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
+				META_DEBUG(api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
 			status=MRES_UNSET;
 		}
 	} else {
-		META_DEBUG(loglevel, ("Skipped (supercede) %s:%s()", (api==e_api_engine)?"engine":GameDLL.file, api_info->name));
-		orig_ret = override_ret;
-		pub_orig_ret = override_ret;
-		PublicMetaGlobals.orig_ret = pub_orig_ret.getptr();
+		META_DEBUG(api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
+		rv.orig_ret = rv.override_ret;
 	}
 
 	//Post plugin functions
-	prev_mres=MRES_UNSET;
-	for(i=0; likely(i < Plugins->endlist); i++) {
-		iplug=&Plugins->plist[i];
-		
-		if(unlikely(iplug->status != PL_RUNNING))
+	PublicMetaGlobals.prev_mres = MRES_UNSET;
+	plist=Plugins->plist;
+	endi=Plugins->endlist;
+	for(i=0; likely(i < endi); i++) {
+		if(unlikely(plist[i].status != PL_RUNNING))
 			continue;
-		
-		api_table = iplug->get_api_post_table(api);
+
+		const void *api_table = plist[i].get_api_post_table(api);
 		if(likely(!api_table)) {
 			//plugin doesn't provide this api table
 			continue;
 		}
-		
-		pfn_routine=get_api_function(api_table, func_offset);
+
+		void *pfn_routine=get_api_function(api_table, func_offset);
 		if(likely(!pfn_routine)) {
 			//plugin doesn't provide this function
 			continue;
 		}
-		
+
+		META_DEBUG(api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
-		PublicMetaGlobals.prev_mres = prev_mres;
 		PublicMetaGlobals.status = status;
-		pub_orig_ret = orig_ret;
-		PublicMetaGlobals.orig_ret = pub_orig_ret.getptr();
-		if(unlikely(status==MRES_OVERRIDE)) {
-			pub_override_ret = override_ret;
-			PublicMetaGlobals.override_ret = pub_override_ret.getptr();
-		}
-		
+		PublicMetaGlobals.orig_ret = rv.orig_ret.getptr();
+		PublicMetaGlobals.override_ret = rv.override_ret.getptr();
+
+		backup_rv = rv;
+
 		// call plugin
-		META_DEBUG(loglevel, ("Calling %s:%s_Post()", iplug->file, api_info->name));
-		dllret = class_ret_t(api_info->api_caller(pfn_routine, packed_args));
+		class_ret_t dllret = class_ret_t(api_info.api_caller(pfn_routine, packed_args));
 		API_UNPAUSE_TSC_TRACKING();
-		
+
+		rv = backup_rv;
+
 		// plugin's result code
-		mres=PublicMetaGlobals.mres;
+		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
 			status = mres;
-		
+
 		// save this for successive plugins to see
-		prev_mres = mres;
-		
+		PublicMetaGlobals.prev_mres = mres;
+
 		if(unlikely(mres==MRES_OVERRIDE)) {
-			pub_override_ret = dllret;
-			override_ret = dllret;
+			rv.override_ret = dllret;
 		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", iplug->file, api_info->name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plist[i].file, api_info.name);
 		}
 		else if(unlikely(mres==MRES_SUPERCEDE)) {
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", iplug->file, api_info->name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plist[i].file, api_info.name);
 		}
 	}
 	
@@ -398,10 +385,10 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 
 	//return value is passed through ret_init!
 	if(likely(status!=MRES_OVERRIDE)) {
-		return(*(void**)orig_ret.getptr());
+		return(*(void**)rv.orig_ret.getptr());
 	} else {
-		META_DEBUG(loglevel, ("Returning (override) %s()", api_info->name));
-		return(*(void**)override_ret.getptr());
+		META_DEBUG(api_info.loglevel, ("Returning (override) %s()", api_info.name));
+		return(*(void**)rv.override_ret.getptr());
 	}
 }
 

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -72,7 +72,7 @@ static inline void copy_meta_globals(meta_globals_t *dst, const meta_globals_t *
 #endif
 }
 
-static inline const char * api_owner_name(enum_api_t api) {
+static NOINLINE const char * api_owner_name(enum_api_t api) {
 	return (api == e_api_engine) ? "engine" : GameDLL.file;
 }
 
@@ -86,8 +86,17 @@ inline const api_info_t * DLLINTERNAL get_api_info(enum_api_t api, unsigned int 
 	return((const api_info_t *)((unsigned long)api_info_tables[api] + api_info_offset));
 }
 
+// META_DEBUG that can be compile-time eliminated via template parameter
+#ifndef __BUILD_FAST_METAMOD__
+  #define MAYBE_META_DEBUG(do_debug, level, args) \
+	do { if(do_debug) { META_DEBUG(level, args); } } while(0)
+#else
+  #define MAYBE_META_DEBUG(do_debug, level, args) do { break; } while(0)
+#endif
+
 // simplified 'void' version of main hook function
-void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
+template <bool do_debug>
+static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
 	int i, endi;
 	META_RES status;
@@ -124,7 +133,7 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 			continue;
 		}
 
-		META_DEBUG(api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -154,7 +163,7 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 		if(likely(api_table)) {
 			void *pfn_routine = get_api_function(api_table, func_offset);
 			if(likely(pfn_routine)) {
-				META_DEBUG(api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
+				MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
 				api_info.api_caller(pfn_routine, packed_args);
 				API_UNPAUSE_TSC_TRACKING();
 			} else {
@@ -166,11 +175,11 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 		} else {
 			// don't complain for NULL NEW_DLL_FUNCTIONS-table
 			if(unlikely(api != e_api_newapi))
-				META_DEBUG(api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
+				MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
 			status=MRES_UNSET;
 		}
 	} else
-		META_DEBUG(api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
 
 	//Post plugin functions
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
@@ -192,7 +201,7 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 			continue;
 		}
 
-		META_DEBUG(api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -219,8 +228,19 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
 }
 
+void DLLINTERNAL NOINLINE main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
+#ifndef __BUILD_FAST_METAMOD__
+	if(unlikely(meta_debug_value >= get_api_info(api, api_info_offset)->loglevel))
+		main_hook_function_void_t<true>(api_info_offset, api, func_offset, packed_args);
+	else
+#endif
+		main_hook_function_void_t<false>(api_info_offset, api, func_offset, packed_args);
+}
+
 // full return typed version of main hook function
-void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
+template <bool do_debug>
+static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
+						      unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
 	int i, endi;
 	META_RES status;
@@ -265,7 +285,7 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 			continue;
 		}
 
-		META_DEBUG(api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -305,7 +325,7 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 		if(likely(api_table)) {
 			void *pfn_routine = get_api_function(api_table, func_offset);
 			if(likely(pfn_routine)) {
-				META_DEBUG(api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
+				MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", api_owner_name(api), api_info.name));
 				class_ret_t dllret = class_ret_t(api_info.api_caller(pfn_routine, packed_args));
 				API_UNPAUSE_TSC_TRACKING();
 				rv.orig_ret = dllret;
@@ -318,11 +338,11 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 		} else {
 			// don't complain for NULL NEW_DLL_FUNCTIONS-table
 			if(unlikely(api != e_api_newapi))
-				META_DEBUG(api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
+				MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("No api table defined for api call: %s:%s", api_owner_name(api), api_info.name));
 			status=MRES_UNSET;
 		}
 	} else {
-		META_DEBUG(api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Skipped (supercede) %s:%s()", api_owner_name(api), api_info.name));
 		rv.orig_ret = rv.override_ret;
 	}
 
@@ -346,7 +366,7 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 			continue;
 		}
 
-		META_DEBUG(api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -380,16 +400,26 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plist[i].file, api_info.name);
 		}
 	}
-	
+
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
 
 	//return value is passed through ret_init!
 	if(likely(status!=MRES_OVERRIDE)) {
 		return(*(void**)rv.orig_ret.getptr());
 	} else {
-		META_DEBUG(api_info.loglevel, ("Returning (override) %s()", api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Returning (override) %s()", api_info.name));
 		return(*(void**)rv.override_ret.getptr());
 	}
+}
+
+void * DLLINTERNAL NOINLINE main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
+					       unsigned int func_offset, const void * packed_args) {
+#ifndef __BUILD_FAST_METAMOD__
+	if(unlikely(meta_debug_value >= get_api_info(api, api_info_offset)->loglevel))
+		return main_hook_function_t<true>(ret_init, api_info_offset, api, func_offset, packed_args);
+	else
+#endif
+		return main_hook_function_t<false>(ret_init, api_info_offset, api, func_offset, packed_args);
 }
 
 //

--- a/metamod/comp_dep.h
+++ b/metamod/comp_dep.h
@@ -96,6 +96,13 @@
 	#define FORCE_STACK_ALIGN
 #endif
 
+// Prevent function inlining to reduce code size at call sites
+#if defined(__GNUC__)
+	#define NOINLINE __attribute__((noinline))
+#else
+	#define NOINLINE
+#endif
+
 // Manual branch optimization for GCC 3.0.0 and newer
 #if !defined(__GNUC__) || __GNUC__ < 3
 	#define likely(x) (x)


### PR DESCRIPTION
## Summary
Optimize `main_hook_function_void` and `main_hook_function` codegen on i686 where register pressure is high (only 4 callee-saved GPRs).

**Commit 1: Reduce register pressure in hook dispatch functions**
- Pack `orig_ret` and `override_ret` into a struct for single backup/restore
- Eliminate `prev_mres` and `iplug` locals, write directly to `PublicMetaGlobals`
- Narrow `mres` and `api_table` variable scope to point of use
- Hoist `Plugins->plist` and `Plugins->endlist` into locals before both loops
- Copy `api_info` to stack to eliminate pointer indirection in hot path
- Set `override_ret` pointer unconditionally instead of only on SUPERCEDE
- Extract `api_owner_name()` helper for repeated engine/gamedll name lookup

**Commit 2: Template-split into debug and non-debug variants**
- Template on `do_debug` bool to generate two instantiations per function
- NOINLINE wrapper checks `meta_debug_value` once and dispatches
- Both variants inlined into wrapper; compiler places cold paths after `ret`
- NOINLINE `api_owner_name()` to deduplicate across cold call sites
- Add `NOINLINE` macro to `comp_dep.h`

## Test plan
- [x] Optimized LTO build codegen verified at each step
- [x] `opt-fast` build (`__BUILD_FAST_METAMOD__`) still works
- [x] CI passes (linux + win32 builds, unit tests)