### PR TITLE
Pre-filtered per-table plugin arrays for hook dispatch

### DIFF
--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -98,9 +98,10 @@ inline const api_info_t * DLLINTERNAL get_api_info(enum_api_t api, unsigned int 
 template <bool do_debug>
 static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
-	int i, endi;
+	const api_plugin_list_t *list;
+	int i, count;
+	MPlugin * const *plugs;
 	META_RES status;
-	MPlugin *plist;
 	meta_globals_t saved_meta_globals;
 
 	//passing offset from api wrapper function makes code faster/smaller
@@ -115,25 +116,15 @@ static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_o
 
 	//Pre plugin functions
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
-	plist=Plugins->plist;
-	endi=Plugins->endlist;
-	for(i=0; likely(i < endi); i++) {
-		if(unlikely(plist[i].status != PL_RUNNING))
+	list = Plugins->get_hook_list(api);
+	count = list->count;
+	plugs = list->plugs;
+	for(i=0; likely(i < count); i++) {
+		void *pfn_routine=get_api_function(plugs[i]->get_api_table(api), func_offset);
+		if(likely(!pfn_routine))
 			continue;
 
-		const void *api_table = plist[i].get_api_table(api);
-		if(likely(!api_table)) {
-			//plugin doesn't provide this api table
-			continue;
-		}
-
-		void *pfn_routine=get_api_function(api_table, func_offset);
-		if(likely(!pfn_routine)) {
-			//plugin doesn't provide this function
-			continue;
-		}
-
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plugs[i]->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -152,7 +143,7 @@ static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_o
 		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", plist[i].file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plugs[i]->file, api_info.name);
 	}
 
 	//Api call
@@ -183,25 +174,15 @@ static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_o
 
 	//Post plugin functions
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
-	plist=Plugins->plist;
-	endi=Plugins->endlist;
-	for(i=0; likely(i < endi); i++) {
-		if(unlikely(plist[i].status != PL_RUNNING))
+	list = Plugins->get_hook_post_list(api);
+	count = list->count;
+	plugs = list->plugs;
+	for(i=0; likely(i < count); i++) {
+		void *pfn_routine=get_api_function(plugs[i]->get_api_post_table(api), func_offset);
+		if(likely(!pfn_routine))
 			continue;
 
-		const void *api_table = plist[i].get_api_post_table(api);
-		if(likely(!api_table)) {
-			//plugin doesn't provide this api table
-			continue;
-		}
-
-		void *pfn_routine=get_api_function(api_table, func_offset);
-		if(likely(!pfn_routine)) {
-			//plugin doesn't provide this function
-			continue;
-		}
-
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plugs[i]->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -220,9 +201,9 @@ static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_o
 		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plist[i].file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plugs[i]->file, api_info.name);
 		else if(unlikely(mres==MRES_SUPERCEDE))
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plist[i].file, api_info.name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plugs[i]->file, api_info.name);
 	}
 
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
@@ -242,9 +223,10 @@ template <bool do_debug>
 static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
 						      unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
-	int i, endi;
+	const api_plugin_list_t *list;
+	int i, count;
+	MPlugin * const *plugs;
 	META_RES status;
-	MPlugin *plist;
 	meta_globals_t saved_meta_globals;
 	struct {
 	  class_ret_t orig_ret;
@@ -267,25 +249,15 @@ static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init
 
 	//Pre plugin functions
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
-	plist=Plugins->plist;
-	endi=Plugins->endlist;
-	for(i=0; likely(i < endi); i++) {
-		if(unlikely(plist[i].status != PL_RUNNING))
+	list = Plugins->get_hook_list(api);
+	count = list->count;
+	plugs = list->plugs;
+	for(i=0; likely(i < count); i++) {
+		void *pfn_routine=get_api_function(plugs[i]->get_api_table(api), func_offset);
+		if(likely(!pfn_routine))
 			continue;
 
-		const void *api_table = plist[i].get_api_table(api);
-		if(likely(!api_table)) {
-			//plugin doesn't provide this api table
-			continue;
-		}
-
-		void *pfn_routine=get_api_function(api_table, func_offset);
-		if(likely(!pfn_routine)) {
-			//plugin doesn't provide this function
-			continue;
-		}
-
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plugs[i]->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -313,7 +285,7 @@ static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init
 			rv.override_ret = dllret;
 		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", plist[i].file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plugs[i]->file, api_info.name);
 		}
 	}
 
@@ -348,25 +320,15 @@ static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init
 
 	//Post plugin functions
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
-	plist=Plugins->plist;
-	endi=Plugins->endlist;
-	for(i=0; likely(i < endi); i++) {
-		if(unlikely(plist[i].status != PL_RUNNING))
+	list = Plugins->get_hook_post_list(api);
+	count = list->count;
+	plugs = list->plugs;
+	for(i=0; likely(i < count); i++) {
+		void *pfn_routine=get_api_function(plugs[i]->get_api_post_table(api), func_offset);
+		if(likely(!pfn_routine))
 			continue;
 
-		const void *api_table = plist[i].get_api_post_table(api);
-		if(likely(!api_table)) {
-			//plugin doesn't provide this api table
-			continue;
-		}
-
-		void *pfn_routine=get_api_function(api_table, func_offset);
-		if(likely(!pfn_routine)) {
-			//plugin doesn't provide this function
-			continue;
-		}
-
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plist[i].file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plugs[i]->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -394,10 +356,10 @@ static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init
 			rv.override_ret = dllret;
 		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plist[i].file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plugs[i]->file, api_info.name);
 		}
 		else if(unlikely(mres==MRES_SUPERCEDE)) {
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plist[i].file, api_info.name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plugs[i]->file, api_info.name);
 		}
 	}
 

--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -56,12 +56,18 @@ MPluginList::MPluginList(const char *ifile)
 	// store filename of ini file
 	STRNCPY(inifile, ifile, sizeof(inifile));
 	// initialize array
+	memset(hook_lists, 0, sizeof(hook_lists));
+	hook_list_data = NULL;
 	for(i=0; i < size; i++) {
 		//reset to empty
 		plist[i].index=i+1;
 		reset_plugin(&plist[i]);
 	}
 	endlist=0;
+}
+
+MPluginList::~MPluginList(void) {
+	free(hook_list_data);
 }
 
 // Resets plugin to empty
@@ -160,6 +166,57 @@ void DLLINTERNAL MPluginList::trim_list(void) {
 	
 	if(n < endlist)
 		endlist=n;
+}
+
+void DLLINTERNAL MPluginList::rebuild_hook_lists(void) {
+	int i, total;
+
+	memset(hook_lists, 0, sizeof(hook_lists));
+
+	// First pass: count entries per list.
+	for(i = 0; i < endlist; i++) {
+		if(plist[i].status != PL_RUNNING)
+			continue;
+		for(int api = 0; api < 3; api++) {
+			if(plist[i].get_api_table((enum_api_t)api))
+				hook_lists[api][0].count++;
+			if(plist[i].get_api_post_table((enum_api_t)api))
+				hook_lists[api][1].count++;
+		}
+	}
+
+	// Allocate single block for all lists back-to-back.
+	total = 0;
+	for(i = 0; i < 6; i++)
+		total += ((api_plugin_list_t *)hook_lists)[i].count;
+
+	if(total > 0) {
+		hook_list_data = (MPlugin **)realloc(hook_list_data, total * sizeof(MPlugin *));
+	} else {
+		free(hook_list_data);
+		hook_list_data = NULL;
+	}
+
+	// Assign plugs pointers into the allocation.
+	MPlugin **ptr = hook_list_data;
+	for(i = 0; i < 6; i++) {
+		api_plugin_list_t *list = &((api_plugin_list_t *)hook_lists)[i];
+		list->plugs = list->count ? ptr : NULL;
+		ptr += list->count;
+	}
+
+	// Second pass: fill in plugin pointers (reuse counts as write indices).
+	int idx[3][2] = {};
+	for(i = 0; i < endlist; i++) {
+		if(plist[i].status != PL_RUNNING)
+			continue;
+		for(int api = 0; api < 3; api++) {
+			if(plist[i].get_api_table((enum_api_t)api))
+				hook_lists[api][0].plugs[idx[api][0]++] = &plist[i];
+			if(plist[i].get_api_post_table((enum_api_t)api))
+				hook_lists[api][1].plugs[idx[api][1]++] = &plist[i];
+		}
+	}
 }
 
 // Find a plugin with the given plid.

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -49,6 +49,12 @@
 // Width required to printf above MAX, for show() functions.
 #define WIDTH_MAX_PLUGINS	2
 
+// Pre-filtered plugin list for a single API group + phase combination.
+// Contains only running plugins that have a non-NULL table for that group.
+struct api_plugin_list_t {
+	int count;
+	MPlugin **plugs;
+};
 
 // A list of plugins.
 class MPluginList : public class_metamod_new {
@@ -58,9 +64,19 @@ class MPluginList : public class_metamod_new {
 		int size;					// size of list, ie MAX_PLUGINS
 		int endlist;					// index of last used entry
 		char inifile[PATH_MAX];				// full pathname
+		api_plugin_list_t hook_lists[3][2];
+		MPlugin **hook_list_data;
 
-	// constructor:
+		inline DLLINTERNAL const api_plugin_list_t * get_hook_list(enum_api_t api) {
+			return(&hook_lists[api][0]);
+		}
+		inline DLLINTERNAL const api_plugin_list_t * get_hook_post_list(enum_api_t api) {
+			return(&hook_lists[api][1]);
+		}
+
+	// constructor/destructor:
 		MPluginList(const char *ifile) DLLINTERNAL;
+		~MPluginList(void) DLLINTERNAL;
 
 	// functions:
 		void DLLINTERNAL reset_plugin(MPlugin *pl_find);
@@ -84,6 +100,7 @@ class MPluginList : public class_metamod_new {
 
 		mBOOL DLLINTERNAL load(void);				// load the list, at startup
 		mBOOL DLLINTERNAL refresh(PLUG_LOADTIME now);		// update from re-read inifile
+		void DLLINTERNAL rebuild_hook_lists(void);
 		void DLLINTERNAL unpause_all(void);			// unpause any paused plugins
 		void DLLINTERNAL retry_all(PLUG_LOADTIME now);		// retry any pending plugin actions
 		void DLLINTERNAL show(int source_index);		// list plugins to console

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -611,7 +611,8 @@ mBOOL DLLINTERNAL MPlugin::load(PLUG_LOADTIME now) {
 	
 	status=PL_RUNNING;
 	action=PA_NONE;
-		
+	Plugins->rebuild_hook_lists();
+
 	// If not loading at server startup, then need to call plugin's
 	// GameInit, since we've passed that.
 	if(now != PT_STARTUP) {
@@ -1100,6 +1101,7 @@ mBOOL DLLINTERNAL MPlugin::unload(PLUG_LOADTIME now, PL_UNLOAD_REASON reason, PL
 		action=PA_LOAD;
 		clear();
 	}
+	Plugins->rebuild_hook_lists();
 	META_LOG("dll: Unloaded plugin '%s' for reason '%s'", desc, str_reason(reason, real_reason));
 	return(mTRUE);
 }
@@ -1204,6 +1206,7 @@ mBOOL MPlugin::pause(void) {
 	}
 
 	status=PL_PAUSED;
+	Plugins->rebuild_hook_lists();
 	META_LOG("Paused plugin '%s'", desc);
 	return(mTRUE);
 }
@@ -1217,6 +1220,7 @@ mBOOL DLLINTERNAL MPlugin::unpause(void) {
 		RETURN_ERRNO(mFALSE, ME_BADREQ);
 	}
 	status=PL_RUNNING;
+	Plugins->rebuild_hook_lists();
 	META_LOG("Unpaused plugin '%s'", desc);
 	return(mTRUE);
 }

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -186,6 +186,7 @@ static void setup_one_plugin(void)
 	memset(&plugin1_pre_funcs, 0, sizeof(plugin1_pre_funcs));
 	memset(&plugin1_post_funcs, 0, sizeof(plugin1_post_funcs));
 
+	free(test_plugins.hook_list_data);
 	memset(&test_plugins, 0, sizeof(test_plugins));
 	MPlugin *plug = &test_plugins.plist[0];
 	memset(plug, 0, sizeof(*plug));
@@ -196,6 +197,7 @@ static void setup_one_plugin(void)
 	plug->tables.dllapi = &plugin1_pre_funcs;
 	plug->post_tables.dllapi = &plugin1_post_funcs;
 	test_plugins.endlist = 1;
+	test_plugins.rebuild_hook_lists();
 }
 
 static void setup_two_plugins(void)
@@ -214,6 +216,7 @@ static void setup_two_plugins(void)
 	plug2->tables.dllapi = &plugin2_pre_funcs;
 	plug2->post_tables.dllapi = &plugin2_post_funcs;
 	test_plugins.endlist = 2;
+	test_plugins.rebuild_hook_lists();
 }
 
 static void teardown(void)
@@ -258,6 +261,7 @@ static int test_no_plugins_calls_gamedll(void)
 	setup_one_plugin();
 	test_plugins.endlist = 0;
 	test_plugins.plist[0].status = PL_EMPTY;
+	test_plugins.rebuild_hook_lists();
 
 	call_hooked_GameInit();
 	ASSERT_TRUE(g_gamedll_called == 1);
@@ -447,6 +451,7 @@ static int test_paused_plugin_skipped(void)
 	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
 	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
 	test_plugins.plist[0].status = PL_PAUSED;
+	test_plugins.rebuild_hook_lists();
 	g_plugin1_pre_mres = MRES_IGNORED;
 	g_plugin2_pre_mres = MRES_IGNORED;
 
@@ -480,6 +485,7 @@ static int test_plugin_no_table_skipped(void)
 	setup_one_plugin();
 	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
 	test_plugins.plist[0].tables.dllapi = NULL;
+	test_plugins.rebuild_hook_lists();
 
 	call_hooked_GameInit();
 	ASSERT_TRUE(g_plugin1_pre_called == 0);
@@ -498,6 +504,7 @@ static int test_return_no_plugins(void)
 	TEST("dispatch return - no plugins, returns game DLL value");
 	setup_one_plugin();
 	test_plugins.endlist = 0;
+	test_plugins.rebuild_hook_lists();
 
 	int ret = call_hooked_Spawn();
 	ASSERT_TRUE(ret == 42);
@@ -662,6 +669,7 @@ static int test_return_paused_plugin_skipped(void)
 	g_plugin1_pre_mres = MRES_IGNORED;
 	g_plugin1_post_mres = MRES_IGNORED;
 	test_plugins.plist[1].status = PL_PAUSED;
+	test_plugins.rebuild_hook_lists();
 	plugin2_post_funcs.pfnSpawn = (int (*)(edict_t *))plugin1_post_Spawn_unset;
 
 	int ret = call_hooked_Spawn();
@@ -681,6 +689,7 @@ static int test_return_plugin_no_post_table(void)
 	plugin1_pre_funcs.pfnSpawn = plugin1_pre_Spawn;
 	g_plugin1_pre_mres = MRES_IGNORED;
 	test_plugins.plist[1].post_tables.dllapi = NULL;
+	test_plugins.rebuild_hook_lists();
 
 	int ret = call_hooked_Spawn();
 	ASSERT_TRUE(g_gamedll_called == 1);
@@ -960,6 +969,7 @@ static int test_void_null_post_table(void)
 	test_plugins.plist[0].post_tables.dllapi = NULL;
 	// Plugin 2 has no hooks at all
 	test_plugins.plist[1].post_tables.dllapi = NULL;
+	test_plugins.rebuild_hook_lists();
 
 	call_hooked_GameInit();
 	ASSERT_TRUE(g_plugin1_pre_called == 1);
@@ -985,6 +995,7 @@ static int test_return_null_pre_table(void)
 	plugin2_pre_funcs.pfnSpawn = plugin2_pre_Spawn;
 	g_plugin2_pre_mres = MRES_IGNORED;
 	test_plugins.plist[1].post_tables.dllapi = NULL;
+	test_plugins.rebuild_hook_lists();
 
 	int ret = call_hooked_Spawn();
 	ASSERT_TRUE(g_plugin1_pre_called == 0);

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -4072,6 +4072,468 @@ static int test_load_and_refresh_reload(void)
 }
 
 // ============================================================
+// rebuild_hook_lists
+// ============================================================
+
+static DLL_FUNCTIONS fake_dllapi;
+static DLL_FUNCTIONS fake_dllapi2;
+static NEW_DLL_FUNCTIONS fake_newapi;
+static enginefuncs_t fake_engine_funcs;
+
+static int test_rebuild_empty(void)
+{
+	TEST("rebuild_hook_lists - empty list produces zero counts");
+	setup_globals();
+	HeapPluginList list("test.ini");
+	list->endlist = 0;
+	list->rebuild_hook_lists();
+	for(int api = 0; api < 3; api++) {
+		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+	}
+	ASSERT_TRUE(list->hook_list_data == NULL);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_one_running_dllapi(void)
+{
+	TEST("rebuild_hook_lists - one running plugin with dllapi tables");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	plug->post_tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_engine)->count, 0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_list(e_api_newapi)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_engine)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_newapi)->count, 0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_one_running_all_tables(void)
+{
+	TEST("rebuild_hook_lists - one plugin with all 3 api groups");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_newapi, 0, sizeof(fake_newapi));
+	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.engine = &fake_engine_funcs;
+	plug->tables.dllapi = &fake_dllapi;
+	plug->tables.newapi = &fake_newapi;
+	plug->post_tables.engine = &fake_engine_funcs;
+	plug->post_tables.dllapi = &fake_dllapi;
+	plug->post_tables.newapi = &fake_newapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	for(int api = 0; api < 3; api++) {
+		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 1);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 1);
+		ASSERT_PTR_EQ(list->get_hook_list((enum_api_t)api)->plugs[0], plug);
+		ASSERT_PTR_EQ(list->get_hook_post_list((enum_api_t)api)->plugs[0], plug);
+	}
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_pre_only(void)
+{
+	TEST("rebuild_hook_lists - plugin with pre table only, no post");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	plug->post_tables.dllapi = NULL;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_PTR_NULL(list->get_hook_post_list(e_api_dllapi)->plugs);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_post_only(void)
+{
+	TEST("rebuild_hook_lists - plugin with post table only, no pre");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = NULL;
+	plug->post_tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
+	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi)->plugs);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_skips_non_running(void)
+{
+	TEST("rebuild_hook_lists - skips paused/unloaded/empty plugins");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+
+	PLUG_STATUS skip_statuses[] = { PL_PAUSED, PL_EMPTY, PL_VALID, PL_OPENED };
+	for(int s = 0; s < 4; s++) {
+		MPlugin *plug = &list->plist[s];
+		memset(plug, 0, sizeof(*plug));
+		plug->status = skip_statuses[s];
+		plug->tables.dllapi = &fake_dllapi;
+		plug->post_tables.dllapi = &fake_dllapi;
+	}
+	list->endlist = 4;
+
+	list->rebuild_hook_lists();
+
+	for(int api = 0; api < 3; api++) {
+		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+	}
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_mixed_statuses(void)
+{
+	TEST("rebuild_hook_lists - only PL_RUNNING included among mixed");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_PAUSED;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->status = PL_EMPTY;
+	plug2->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plug3 = &list->plist[3];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[1], plug3);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_two_plugins_order(void)
+{
+	TEST("rebuild_hook_lists - plugin order preserved");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+	plug0->post_tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+	plug1->post_tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[1], plug1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug0);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[1], plug1);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_different_api_groups(void)
+{
+	TEST("rebuild_hook_lists - plugins in different api groups");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_newapi, 0, sizeof(fake_newapi));
+	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.engine = &fake_engine_funcs;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi;
+	plug1->post_tables.newapi = &fake_newapi;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_engine)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_engine)->plugs[0], plug0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug1);
+	ASSERT_INT(list->get_hook_list(e_api_newapi)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_engine)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_newapi)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_newapi)->plugs[0], plug1);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_realloc_shrinks(void)
+{
+	TEST("rebuild_hook_lists - rebuild after unload shrinks lists");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+
+	plug1->status = PL_EMPTY;
+	list->rebuild_hook_lists();
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_to_empty_frees(void)
+{
+	TEST("rebuild_hook_lists - all plugins removed frees allocation");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+	ASSERT_PTR_NOT_NULL(list->hook_list_data);
+
+	plug->status = PL_EMPTY;
+	list->rebuild_hook_lists();
+	ASSERT_PTR_NULL(list->hook_list_data);
+	for(int api = 0; api < 3; api++) {
+		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+	}
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_null_tables_ignored(void)
+{
+	TEST("rebuild_hook_lists - NULL table pointers not counted");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.engine = NULL;
+	plug->tables.dllapi = NULL;
+	plug->tables.newapi = NULL;
+	plug->post_tables.engine = NULL;
+	plug->post_tables.dllapi = NULL;
+	plug->post_tables.newapi = NULL;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	for(int api = 0; api < 3; api++) {
+		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+	}
+	ASSERT_PTR_NULL(list->hook_list_data);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_plugs_contiguous(void)
+{
+	TEST("rebuild_hook_lists - plugs arrays are contiguous in memory");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.engine = &fake_engine_funcs;
+	plug0->tables.dllapi = &fake_dllapi;
+	plug0->post_tables.dllapi = &fake_dllapi;
+
+	list->endlist = 1;
+	list->rebuild_hook_lists();
+
+	// All plugs pointers should point into hook_list_data
+	MPlugin **base = list->hook_list_data;
+	ASSERT_PTR_NOT_NULL(base);
+
+	// engine pre (1) + engine post (0) + dllapi pre (1) + dllapi post (1) = 3 total
+	const api_plugin_list_t *eng_pre = list->get_hook_list(e_api_engine);
+	const api_plugin_list_t *dll_pre = list->get_hook_list(e_api_dllapi);
+	const api_plugin_list_t *dll_post = list->get_hook_post_list(e_api_dllapi);
+
+	ASSERT_PTR_EQ(eng_pre->plugs, base);
+	ASSERT_PTR_EQ(dll_pre->plugs, base + 1);
+	ASSERT_PTR_EQ(dll_post->plugs, base + 2);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_repeated_calls(void)
+{
+	TEST("rebuild_hook_lists - repeated rebuilds produce same result");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	plug->post_tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
+
+	list->rebuild_hook_lists();
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_endlist_bounds(void)
+{
+	TEST("rebuild_hook_lists - only scans up to endlist");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 1;
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -4274,6 +4736,23 @@ int main(void)
 	fail |= test_refresh_pa_load_success();
 	fail |= test_load_success();
 	fail |= test_load_and_refresh_reload();
+
+	// rebuild_hook_lists
+	fail |= test_rebuild_empty();
+	fail |= test_rebuild_one_running_dllapi();
+	fail |= test_rebuild_one_running_all_tables();
+	fail |= test_rebuild_pre_only();
+	fail |= test_rebuild_post_only();
+	fail |= test_rebuild_skips_non_running();
+	fail |= test_rebuild_mixed_statuses();
+	fail |= test_rebuild_two_plugins_order();
+	fail |= test_rebuild_different_api_groups();
+	fail |= test_rebuild_realloc_shrinks();
+	fail |= test_rebuild_to_empty_frees();
+	fail |= test_rebuild_null_tables_ignored();
+	fail |= test_rebuild_plugs_contiguous();
+	fail |= test_rebuild_repeated_calls();
+	fail |= test_rebuild_endlist_bounds();
 
 	system("rm -rf /tmp/test_mlist_gd");
 


### PR DESCRIPTION
## Summary

- Replace the dispatch loop that iterates all plugin slots (3 checks per plugin: status, table NULL, fn ptr NULL) with pre-filtered arrays containing only running plugins with a non-NULL table for each API group and phase
- Inner loop reduced from 3 branches to 1 (fn ptr NULL only), stride from sizeof(MPlugin) to a pointer
- Six lists (3 API groups × 2 phases) in MPluginList, rebuilt on plugin state transitions (load/unload/pause/unpause)
- Plugin pointer arrays dynamically allocated in a single block, sized to actual number of active entries

## Codegen comparison (i686, GCC 12, -O2 -flto)

Inner loop skip path (common case, plugin has no hook for this function):

**Before** — 10 insns, 3 branches:
```asm
cmpl  $0x5,-0x1044(%edi)     ; status == PL_RUNNING?
jne   <skip>                  ; branch 1
mov   -0x1034(%edi,%ebx,4),%eax ; api_table
test  %eax,%eax
jne   <has_table>             ; branch 2
add   $0x1,%ecx
add   $0x2198,%edi           ; stride = sizeof(MPlugin)
cmp   %ecx,%ebp
jne   <loop>                  ; branch 3
```

**After** — 9 insns, 1 branch:
```asm
mov   (%edi,%ebx,4),%eax     ; plugs[i]
mov   0xc(%esp),%edx         ; func_offset
mov   0x4(%eax,%ecx,4),%eax  ; api_table
mov   (%eax,%edx,1),%eax     ; pfn_routine
test  %eax,%eax
jne   <call>                  ; single branch
add   $0x1,%ebx
cmp   %ebx,%esi              ; count in register
jne   <loop>
```

Function sizes: void +5.9%, retval +5.8% (setup overhead for list pointer/count hoisting).

## Performance (rdtsc, 11th Gen Intel i5-1135G7)

META_PERFMON rdtsc measurement of hook dispatch cycles (excluding plugin callback time). HLDS 16-player valve DM with bots, 5-minute measurement windows, 3 runs each.

| Version | Run 1 | Run 2 | Run 3 | **Mean** |
|---------|-------|-------|-------|----------|
| May 12 baseline (`dfa17ab`) | 265.6 | 275.5 | 261.5 | **267.5** |
| Master (regpressure+template split) | 237.5 | 251.5 | 222.0 | **237.0** |
| **This PR** (pre-filtered arrays) | 200.9 | 213.2 | 233.6 | **215.9** |

- Master vs May 12 baseline: **-11.4%**
- This PR vs master: **-8.9%**
- This PR vs May 12 baseline: **-19.3%**

## Test plan
- [x] All existing tests pass (37/37 test_api_hook, all other suites green)
- [x] Tests updated to call rebuild_hook_lists() after plugin state changes

Closes #88