### PR TITLE
Hot dispatch optimizations

### DIFF
--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -236,7 +236,7 @@ $(STLOBJ): CFLAGS += -Wno-error
 
 # linux .so compile commands
 DO_CC_LINUX=$(CC) $(CFLAGS) -fPIC $(INCLUDEDIRS) -o $@ -c $< $(FILTER)
-LINK_LINUX=$(CC) $(CFLAGS) -shared -ldl -lm -static-libgcc $(EXTRA_LINK) $(OBJ_LINUX) -o $@
+LINK_LINUX=$(CC) $(CFLAGS) -shared -ldl -lm -static-libgcc $(EXTRA_LINK) $(OBJ_LINUX) -Wl,-T,$(METADIR)/hotdata.ld -o $@
 
 # sort by date
 #SRCFILES := $(shell ls -t $(SRCFILES))

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -52,7 +52,7 @@ ifeq "$(OS)" "linux"
 	TST_DIR=$(HOME)/tmp
 else	## windows
 	INST_DIR=/hlserver/tfc/dlls
-	TEST_DIR=/hlserver/tfc/dlls
+	TEST_DIR=/hlserver/test/tfc/dlls
 endif
 
 DLLS_DIR=../dlls
@@ -154,7 +154,7 @@ endif
 CCOPT = $(CCO) $(CC_ARCH) -fno-exceptions -fno-rtti
 
 CCO = -O2 -fomit-frame-pointer
-CCO += -flto -fvisibility=hidden
+CCO += -flto=auto -fvisibility=hidden
 CCO += -fno-strict-aliasing -fno-strict-overflow
 
 # architecture by target type (applies to all build modes)
@@ -308,11 +308,12 @@ opt:
 	$(MAKE) default OPT=opt
 
 linux: do_dll_linux
-win32: do_dll_win32
+win32:
+	$(MAKE) do_dll_win32 OS=windows
 
-linux_opt: 
+linux_opt:
 	$(MAKE) linux OPT=opt
-win32_opt: 
+win32_opt:
 	$(MAKE) win32 OPT=opt
 
 $(TARGET_LINUX): msgs/debug msgs/warning msgs/log msgs/error $(OBJDIR_LINUX) $(OBJ_LINUX)

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -96,7 +96,7 @@ inline const api_info_t * DLLINTERNAL get_api_info(enum_api_t api, unsigned int 
 
 // simplified 'void' version of main hook function
 template <bool do_debug>
-static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
+static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
 	const api_plugin_list_t *list;
 	int i, count;
@@ -209,7 +209,7 @@ static inline void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_o
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
 }
 
-void DLLINTERNAL NOINLINE main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
+HOT_FUNC void DLLINTERNAL NOINLINE main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
 #ifndef __BUILD_FAST_METAMOD__
 	if(unlikely(meta_debug_value >= get_api_info(api, api_info_offset)->loglevel))
 		main_hook_function_void_t<true>(api_info_offset, api, func_offset, packed_args);
@@ -220,7 +220,7 @@ void DLLINTERNAL NOINLINE main_hook_function_void(unsigned int api_info_offset, 
 
 // full return typed version of main hook function
 template <bool do_debug>
-static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
+static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
 						      unsigned int func_offset, const void * packed_args) {
 	api_info_t api_info;
 	const api_plugin_list_t *list;
@@ -374,7 +374,7 @@ static inline void * DLLINTERNAL main_hook_function_t(const class_ret_t ret_init
 	}
 }
 
-void * DLLINTERNAL NOINLINE main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
+HOT_FUNC void * DLLINTERNAL NOINLINE main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api,
 					       unsigned int func_offset, const void * packed_args) {
 #ifndef __BUILD_FAST_METAMOD__
 	if(unlikely(meta_debug_value >= get_api_info(api, api_info_offset)->loglevel))
@@ -388,7 +388,7 @@ void * DLLINTERNAL NOINLINE main_hook_function(const class_ret_t ret_init, unsig
 // Macros for creating api caller functions
 //
 #define BEGIN_API_CALLER_FUNC(ret_type, args_type_code) \
-	void * DLLINTERNAL _COMBINE4(api_caller_, ret_type, _args_, args_type_code)(const void * func, const void * packed_args) { \
+	HOT_FUNC void * DLLINTERNAL _COMBINE4(api_caller_, ret_type, _args_, args_type_code)(const void * func, const void * packed_args) { \
 		_COMBINE2(pack_args_type_, args_type_code) * p ATTRIBUTE(unused)= (_COMBINE2(pack_args_type_, args_type_code) *)packed_args;
 #define END_API_CALLER_FUNC(ret_t, args_t, args) \
 		API_PAUSE_TSC_TRACKING(); \

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -41,16 +41,16 @@
 #include "osdep.h"			//unlikely
 
 // getting pointer with table index is faster than with if-else
-static const void ** api_tables[3] = {
-	(const void**)&Engine.funcs,
-	(const void**)&GameDLL.funcs.dllapi_table,
-	(const void**)&GameDLL.funcs.newapi_table
+static const void * const * const api_tables[3] = {
+	(const void * const *)&Engine.funcs,
+	(const void * const *)&GameDLL.funcs.dllapi_table,
+	(const void * const *)&GameDLL.funcs.newapi_table
 };
 
-static const void ** api_info_tables[3] = {
-	(const void**)&engine_info,
-	(const void**)&dllapi_info,
-	(const void**)&newapi_info
+static const void * const * const api_info_tables[3] = {
+	(const void * const *)&engine_info,
+	(const void * const *)&dllapi_info,
+	(const void * const *)&newapi_info
 };
 
 static inline void copy_meta_globals(meta_globals_t *dst, const meta_globals_t *src) {

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -41,13 +41,13 @@
 #include "osdep.h"			//unlikely
 
 // getting pointer with table index is faster than with if-else
-static const void * const * const api_tables[3] = {
-	(const void * const *)&Engine.funcs,
-	(const void * const *)&GameDLL.funcs.dllapi_table,
-	(const void * const *)&GameDLL.funcs.newapi_table
+static HOT_RODATA const void * const * const api_tables[3] = {
+	(const void * const *)&Engine_funcs,
+	(const void * const *)&GameDLL_funcs.dllapi_table,
+	(const void * const *)&GameDLL_funcs.newapi_table
 };
 
-static const void * const * const api_info_tables[3] = {
+static HOT_RODATA const void * const * const api_info_tables[3] = {
 	(const void * const *)&engine_info,
 	(const void * const *)&dllapi_info,
 	(const void * const *)&newapi_info

--- a/metamod/api_info.cpp
+++ b/metamod/api_info.cpp
@@ -39,237 +39,237 @@
 #include "api_info.h"		// me
 #include "api_hook.h"
 
-// trace flag, loglevel, name
+// loglevel, api_caller, name
 const dllapi_info_t dllapi_info = {
-	{ mFALSE,  3,	api_caller_void_args_void, 	"GameDLLInit" },		// pfnGameInit
-	{ mFALSE,  10,	api_caller_int_args_p, 		"DispatchSpawn" },		// pfnSpawn
-	{ mFALSE,  16,	api_caller_void_args_p,		"DispatchThink" },		// pfnThink
-	{ mFALSE,  9,	api_caller_void_args_2p,	"DispatchUse" },		// pfnUse
-	{ mFALSE,  11,	api_caller_void_args_2p,	"DispatchTouch" },		// pfnTouch
-	{ mFALSE,  9,	api_caller_void_args_2p,	"DispatchBlocked" },		// pfnBlocked
-	{ mFALSE,  10,	api_caller_void_args_2p,	"DispatchKeyValue" },		// pfnKeyValue
-	{ mFALSE,  9,	api_caller_void_args_2p,	"DispatchSave" },		// pfnSave
-	{ mFALSE,  9,	api_caller_int_args_2pi,	"DispatchRestore" },		// pfnRestore
-	{ mFALSE,  20,	api_caller_void_args_p,		"DispatchObjectCollsionBox" },	// pfnSetAbsBox
-	{ mFALSE,  9,	api_caller_void_args_4pi,	"SaveWriteFields" },		// pfnSaveWriteFields
-	{ mFALSE,  9,	api_caller_void_args_4pi,	"SaveReadFields" },		// pfnSaveReadFields
-	{ mFALSE,  9,	api_caller_void_args_p,		"SaveGlobalState" },		// pfnSaveGlobalState
-	{ mFALSE,  9,	api_caller_void_args_p,		"RestoreGlobalState" },		// pfnRestoreGlobalState
-	{ mFALSE,  9,	api_caller_void_args_void, 	"ResetGlobalState" },	// pfnResetGlobalState
-	{ mFALSE,  3,	api_caller_int_args_4p, 	"ClientConnect" },		// pfnClientConnect
-	{ mFALSE,  3,	api_caller_void_args_p,		"ClientDisconnect" },	// pfnClientDisconnect
-	{ mFALSE,  3,	api_caller_void_args_p,		"ClientKill" },			// pfnClientKill
-	{ mFALSE,  3,	api_caller_void_args_p,		"ClientPutInServer" },	// pfnClientPutInServer
-	{ mFALSE,  9,	api_caller_void_args_p,		"ClientCommand" },		// pfnClientCommand
-	{ mFALSE,  11,	api_caller_void_args_2p,	"ClientUserInfoChanged" },	// pfnClientUserInfoChanged
-	{ mFALSE,  3,	api_caller_void_args_p2i,	"ServerActivate" },		// pfnServerActivate
-	{ mFALSE,  3,	api_caller_void_args_void,	"ServerDeactivate" },	// pfnServerDeactivate
-	{ mFALSE,  14,	api_caller_void_args_p,		"PlayerPreThink" },		// pfnPlayerPreThink
-	{ mFALSE,  14,	api_caller_void_args_p,		"PlayerPostThink" },	// pfnPlayerPostThink
-	{ mFALSE,  18,	api_caller_void_args_void,	"StartFrame" },			// pfnStartFrame
-	{ mFALSE,  9,	api_caller_void_args_void,	"ParmsNewLevel" },		// pfnParmsNewLevel
-	{ mFALSE,  9,	api_caller_void_args_void,	"ParmsChangeLevel" },	// pfnParmsChangeLevel
-	{ mFALSE,  9,	api_caller_ptr_args_void,	"GetGameDescription" },	// pfnGetGameDescription
-	{ mFALSE,  9,	api_caller_void_args_2p,	"PlayerCustomization" },	// pfnPlayerCustomization
-	{ mFALSE,  9,	api_caller_void_args_p,		"SpectatorConnect" },	// pfnSpectatorConnect
-	{ mFALSE,  9,	api_caller_void_args_p,		"SpectatorDisconnect" },	// pfnSpectatorDisconnect
-	{ mFALSE,  9,	api_caller_void_args_p,		"SpectatorThink" },		// pfnSpectatorThink
-	{ mFALSE,  3,	api_caller_void_args_p,		"Sys_Error" },			// pfnSys_Error
-	{ mFALSE,  13,	api_caller_void_args_pi,	"PM_Move" },			// pfnPM_Move
-	{ mFALSE,  9,	api_caller_void_args_p,		"PM_Init" },			// pfnPM_Init
-	{ mFALSE,  9,	api_caller_char_args_p,		"PM_FindTextureType" },	// pfnPM_FindTextureType
-	{ mFALSE,  12,	api_caller_void_args_4p,	"SetupVisibility" },	// pfnSetupVisibility
-	{ mFALSE,  12,	api_caller_void_args_pip,	"UpdateClientData" },	// pfnUpdateClientData
-	{ mFALSE,  16,	api_caller_int_args_pi2p2ip,	"AddToFullPack" },		// pfnAddToFullPack
-	{ mFALSE,  9,	api_caller_void_args_2i2pi2p,	"CreateBaseline" },		// pfnCreateBaseline
-	{ mFALSE,  9,	api_caller_void_args_void,	"RegisterEncoders" },	// pfnRegisterEncoders
-	{ mFALSE,  9,	api_caller_int_args_2p,		"GetWeaponData" },		// pfnGetWeaponData
-	{ mFALSE,  15,	api_caller_void_args_2pui,	"CmdStart" },			// pfnCmdStart
-	{ mFALSE,  15,	api_caller_void_args_p,		"CmdEnd" },				// pfnCmdEnd
-	{ mFALSE,  9,	api_caller_int_args_4p,		"ConnectionlessPacket" },	// pfnConnectionlessPacket
-	{ mFALSE,  9,	api_caller_int_args_i2p,	"GetHullBounds" },		// pfnGetHullBounds
-	{ mFALSE,  9,	api_caller_void_args_void,	"CreateInstancedBaselines" },	// pfnCreateInstancedBaselines
-	{ mFALSE,  3,	api_caller_int_args_3p,		"InconsistentFile" },	// pfnInconsistentFile
-	{ mFALSE,  20,	api_caller_int_args_void,	"AllowLagCompensation" },	// pfnAllowLagCompensation
-	{ mFALSE,  0,	NULL, 	NULL },
+	{3,	api_caller_void_args_void, 	"GameDLLInit" },		// pfnGameInit
+	{10,	api_caller_int_args_p, 		"DispatchSpawn" },		// pfnSpawn
+	{16,	api_caller_void_args_p,		"DispatchThink" },		// pfnThink
+	{9,	api_caller_void_args_2p,	"DispatchUse" },		// pfnUse
+	{11,	api_caller_void_args_2p,	"DispatchTouch" },		// pfnTouch
+	{9,	api_caller_void_args_2p,	"DispatchBlocked" },		// pfnBlocked
+	{10,	api_caller_void_args_2p,	"DispatchKeyValue" },		// pfnKeyValue
+	{9,	api_caller_void_args_2p,	"DispatchSave" },		// pfnSave
+	{9,	api_caller_int_args_2pi,	"DispatchRestore" },		// pfnRestore
+	{20,	api_caller_void_args_p,		"DispatchObjectCollsionBox" },	// pfnSetAbsBox
+	{9,	api_caller_void_args_4pi,	"SaveWriteFields" },		// pfnSaveWriteFields
+	{9,	api_caller_void_args_4pi,	"SaveReadFields" },		// pfnSaveReadFields
+	{9,	api_caller_void_args_p,		"SaveGlobalState" },		// pfnSaveGlobalState
+	{9,	api_caller_void_args_p,		"RestoreGlobalState" },		// pfnRestoreGlobalState
+	{9,	api_caller_void_args_void, 	"ResetGlobalState" },	// pfnResetGlobalState
+	{3,	api_caller_int_args_4p, 	"ClientConnect" },		// pfnClientConnect
+	{3,	api_caller_void_args_p,		"ClientDisconnect" },	// pfnClientDisconnect
+	{3,	api_caller_void_args_p,		"ClientKill" },			// pfnClientKill
+	{3,	api_caller_void_args_p,		"ClientPutInServer" },	// pfnClientPutInServer
+	{9,	api_caller_void_args_p,		"ClientCommand" },		// pfnClientCommand
+	{11,	api_caller_void_args_2p,	"ClientUserInfoChanged" },	// pfnClientUserInfoChanged
+	{3,	api_caller_void_args_p2i,	"ServerActivate" },		// pfnServerActivate
+	{3,	api_caller_void_args_void,	"ServerDeactivate" },	// pfnServerDeactivate
+	{14,	api_caller_void_args_p,		"PlayerPreThink" },		// pfnPlayerPreThink
+	{14,	api_caller_void_args_p,		"PlayerPostThink" },	// pfnPlayerPostThink
+	{18,	api_caller_void_args_void,	"StartFrame" },			// pfnStartFrame
+	{9,	api_caller_void_args_void,	"ParmsNewLevel" },		// pfnParmsNewLevel
+	{9,	api_caller_void_args_void,	"ParmsChangeLevel" },	// pfnParmsChangeLevel
+	{9,	api_caller_ptr_args_void,	"GetGameDescription" },	// pfnGetGameDescription
+	{9,	api_caller_void_args_2p,	"PlayerCustomization" },	// pfnPlayerCustomization
+	{9,	api_caller_void_args_p,		"SpectatorConnect" },	// pfnSpectatorConnect
+	{9,	api_caller_void_args_p,		"SpectatorDisconnect" },	// pfnSpectatorDisconnect
+	{9,	api_caller_void_args_p,		"SpectatorThink" },		// pfnSpectatorThink
+	{3,	api_caller_void_args_p,		"Sys_Error" },			// pfnSys_Error
+	{13,	api_caller_void_args_pi,	"PM_Move" },			// pfnPM_Move
+	{9,	api_caller_void_args_p,		"PM_Init" },			// pfnPM_Init
+	{9,	api_caller_char_args_p,		"PM_FindTextureType" },	// pfnPM_FindTextureType
+	{12,	api_caller_void_args_4p,	"SetupVisibility" },	// pfnSetupVisibility
+	{12,	api_caller_void_args_pip,	"UpdateClientData" },	// pfnUpdateClientData
+	{16,	api_caller_int_args_pi2p2ip,	"AddToFullPack" },		// pfnAddToFullPack
+	{9,	api_caller_void_args_2i2pi2p,	"CreateBaseline" },		// pfnCreateBaseline
+	{9,	api_caller_void_args_void,	"RegisterEncoders" },	// pfnRegisterEncoders
+	{9,	api_caller_int_args_2p,		"GetWeaponData" },		// pfnGetWeaponData
+	{15,	api_caller_void_args_2pui,	"CmdStart" },			// pfnCmdStart
+	{15,	api_caller_void_args_p,		"CmdEnd" },				// pfnCmdEnd
+	{9,	api_caller_int_args_4p,		"ConnectionlessPacket" },	// pfnConnectionlessPacket
+	{9,	api_caller_int_args_i2p,	"GetHullBounds" },		// pfnGetHullBounds
+	{9,	api_caller_void_args_void,	"CreateInstancedBaselines" },	// pfnCreateInstancedBaselines
+	{3,	api_caller_int_args_3p,		"InconsistentFile" },	// pfnInconsistentFile
+	{20,	api_caller_int_args_void,	"AllowLagCompensation" },	// pfnAllowLagCompensation
+	{0,	NULL, 	NULL },
 };
 
 const newapi_info_t newapi_info = {
-	{ mFALSE,  16,	api_caller_void_args_p,		"OnFreeEntPrivateData" },	// pfnOnFreeEntPrivateData
-	{ mFALSE,  3,	api_caller_void_args_void,	"GameShutdown" },			// pfnGameShutdown
-	{ mFALSE,  14,	api_caller_int_args_2p,		"ShouldCollide" },			// pfnShouldCollide
+	{16,	api_caller_void_args_p,		"OnFreeEntPrivateData" },	// pfnOnFreeEntPrivateData
+	{3,	api_caller_void_args_void,	"GameShutdown" },			// pfnGameShutdown
+	{14,	api_caller_int_args_2p,		"ShouldCollide" },			// pfnShouldCollide
 	// Added 2005/08/11 (no SDK update):
-	{ mFALSE,  3,	api_caller_void_args_2p,	"CvarValue" },			// pfnCvarValue
+	{3,	api_caller_void_args_2p,	"CvarValue" },			// pfnCvarValue
 	// Added 2005/11/21 (no SDK update):
-	{ mFALSE,  3,	api_caller_void_args_pi2p,	"CvarValue2" },			// pfnCvarValue2
-	{ mFALSE,  0,	NULL, 	NULL },
+	{3,	api_caller_void_args_pi2p,	"CvarValue2" },			// pfnCvarValue2
+	{0,	NULL, 	NULL },
 };
 
 const engine_info_t engine_info = {
-	{ mFALSE,  13,	api_caller_int_args_p,		"PrecacheModel" },		// pfnPrecacheModel
-	{ mFALSE,  13,	api_caller_int_args_p,		"PrecacheSound" },		// pfnPrecacheSound
-	{ mFALSE,  18,	api_caller_void_args_2p,	"SetModel" },			// pfnSetModel
-	{ mFALSE,  34,	api_caller_int_args_p,		"ModelIndex" },			// pfnModelIndex
-	{ mFALSE,  10,	api_caller_int_args_i,		"ModelFrames" },		// pfnModelFrames
-	{ mFALSE,  14,	api_caller_void_args_3p,	"SetSize" },			// pfnSetSize
-	{ mFALSE,  9,	api_caller_void_args_2p,	"ChangeLevel" },		// pfnChangeLevel
-	{ mFALSE,  9,	api_caller_void_args_p,		"GetSpawnParms" },		// pfnGetSpawnParms
-	{ mFALSE,  9,	api_caller_void_args_p,		"SaveSpawnParms" },		// pfnSaveSpawnParms
-	{ mFALSE,  9,	api_caller_float_args_p,	"VecToYaw" },			// pfnVecToYaw
-	{ mFALSE,  14,	api_caller_void_args_2p,	"VecToAngles" },		// pfnVecToAngles
-	{ mFALSE,  9,	api_caller_void_args_2pfi,	"MoveToOrigin" },		// pfnMoveToOrigin
-	{ mFALSE,  9,	api_caller_void_args_p,		"ChangeYaw" },			// pfnChangeYaw
-	{ mFALSE,  9,	api_caller_void_args_p,		"ChangePitch" },		// pfnChangePitch
-	{ mFALSE,  32,	api_caller_ptr_args_3p,		"FindEntityByString" },		// pfnFindEntityByString
-	{ mFALSE,  9,	api_caller_int_args_p,		"GetEntityIllum" },		// pfnGetEntityIllum
-	{ mFALSE,  9,	api_caller_ptr_args_2pf,	"FindEntityInSphere" },		// pfnFindEntityInSphere
-	{ mFALSE,  19,	api_caller_ptr_args_p,		"FindClientInPVS" },		// pfnFindClientInPVS
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"EntitiesInPVS" },		// pfnEntitiesInPVS
-	{ mFALSE,  40,	api_caller_void_args_p,		"MakeVectors" },		// pfnMakeVectors
-	{ mFALSE,  9,	api_caller_void_args_4p,	"AngleVectors" },		// pfnAngleVectors
-	{ mFALSE,  13,	api_caller_ptr_args_void,	"CreateEntity" },		// pfnCreateEntity
-	{ mFALSE,  13,	api_caller_void_args_p,		"RemoveEntity" },		// pfnRemoveEntity
-	{ mFALSE,  13,	api_caller_ptr_args_i,		"CreateNamedEntity" },		// pfnCreateNamedEntity
-	{ mFALSE,  9,	api_caller_void_args_p,		"MakeStatic" },			// pfnMakeStatic
-	{ mFALSE,  9,	api_caller_int_args_p,		"EntIsOnFloor" },		// pfnEntIsOnFloor
-	{ mFALSE,  9,	api_caller_int_args_p,		"DropToFloor" },		// pfnDropToFloor
-	{ mFALSE,  9,	api_caller_int_args_p2fi,	"WalkMove" },			// pfnWalkMove
-	{ mFALSE,  14,	api_caller_void_args_2p,	"SetOrigin" },			// pfnSetOrigin
-	{ mFALSE,  12,	api_caller_void_args_pip2f2i,	"EmitSound" },			// pfnEmitSound
-	{ mFALSE,  12,	api_caller_void_args_3p2f2i,	"EmitAmbientSound" },		// pfnEmitAmbientSound
-	{ mFALSE,  20,	api_caller_void_args_2pi2p,	"TraceLine" },			// pfnTraceLine
-	{ mFALSE,  9,	api_caller_void_args_3p,	"TraceToss" },			// pfnTraceToss
-	{ mFALSE,  9,	api_caller_int_args_3pi2p,	"TraceMonsterHull" },		// pfnTraceMonsterHull
-	{ mFALSE,  9,	api_caller_void_args_2p2i2p,	"TraceHull" },			// pfnTraceHull
-	{ mFALSE,  9,	api_caller_void_args_2pi2p,	"TraceModel" },			// pfnTraceModel
-	{ mFALSE,  15,	api_caller_ptr_args_3p,		"TraceTexture" },		// pfnTraceTexture		// CS: when moving
-	{ mFALSE,  9,	api_caller_void_args_2pif2p,	"TraceSphere" },		// pfnTraceSphere
-	{ mFALSE,  9,	api_caller_void_args_pfp,	"GetAimVector" },		// pfnGetAimVector
-	{ mFALSE,  9,	api_caller_void_args_p,		"ServerCommand" },		// pfnServerCommand
-	{ mFALSE,  9,	api_caller_void_args_void,	"ServerExecute" },		// pfnServerExecute
-	{ mFALSE,  11,	api_caller_void_args_2pV,	"engClientCommand" },		// pfnClientCommand		// d'oh, ClientCommand in dllapi too
-	{ mFALSE,  9,	api_caller_void_args_2p2f,	"ParticleEffect" },		// pfnParticleEffect
-	{ mFALSE,  9,	api_caller_void_args_ip,	"LightStyle" },			// pfnLightStyle
-	{ mFALSE,  9,	api_caller_int_args_p,		"DecalIndex" },			// pfnDecalIndex
-	{ mFALSE,  15,	api_caller_int_args_p,		"PointContents" },		// pfnPointContents		// CS: when moving
-	{ mFALSE,  22,	api_caller_void_args_2i2p,	"MessageBegin" },		// pfnMessageBegin
-	{ mFALSE,  22,	api_caller_void_args_void,	"MessageEnd" },			// pfnMessageEnd
-	{ mFALSE,  30,	api_caller_void_args_i,		"WriteByte" },			// pfnWriteByte
-	{ mFALSE,  23,	api_caller_void_args_i,		"WriteChar" },			// pfnWriteChar
-	{ mFALSE,  24,	api_caller_void_args_i,		"WriteShort" },			// pfnWriteShort
-	{ mFALSE,  23,	api_caller_void_args_i,		"WriteLong" },			// pfnWriteLong
-	{ mFALSE,  23,	api_caller_void_args_f,		"WriteAngle" },			// pfnWriteAngle
-	{ mFALSE,  23,	api_caller_void_args_f,		"WriteCoord" },			// pfnWriteCoord
-	{ mFALSE,  25,	api_caller_void_args_p,		"WriteString" },		// pfnWriteString
-	{ mFALSE,  23,	api_caller_void_args_i,		"WriteEntity" },		// pfnWriteEntity
-	{ mFALSE,  9,	api_caller_void_args_p,		"CVarRegister" },		// pfnCVarRegister
-	{ mFALSE,  21,	api_caller_float_args_p,	"CVarGetFloat" },		// pfnCVarGetFloat
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"CVarGetString" },		// pfnCVarGetString
-	{ mFALSE,  10,	api_caller_void_args_pf,	"CVarSetFloat" },		// pfnCVarSetFloat
-	{ mFALSE,  9,	api_caller_void_args_2p,	"CVarSetString" },		// pfnCVarSetString
-	{ mFALSE,  15,	api_caller_void_args_ipV,	"AlertMessage" },		// pfnAlertMessage
-	{ mFALSE,  17,	api_caller_void_args_2pV,	"EngineFprintf" },		// pfnEngineFprintf
-	{ mFALSE,  14,	api_caller_ptr_args_pi,		"PvAllocEntPrivateData" },	// pfnPvAllocEntPrivateData
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"PvEntPrivateData" },		// pfnPvEntPrivateData
-	{ mFALSE,  9,	api_caller_void_args_p,		"FreeEntPrivateData" },		// pfnFreeEntPrivateData
-	{ mFALSE,  9,	api_caller_ptr_args_i,		"SzFromIndex" },		// pfnSzFromIndex
-	{ mFALSE,  10,	api_caller_int_args_p,		"AllocString" },		// pfnAllocString
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"GetVarsOfEnt" },		// pfnGetVarsOfEnt
-	{ mFALSE,  14,	api_caller_ptr_args_i,		"PEntityOfEntOffset" },		// pfnPEntityOfEntOffset
-	{ mFALSE,  19,	api_caller_int_args_p,		"EntOffsetOfPEntity" },		// pfnEntOffsetOfPEntity
-	{ mFALSE,  14,	api_caller_int_args_p,		"IndexOfEdict" },		// pfnIndexOfEdict
-	{ mFALSE,  17,	api_caller_ptr_args_i,		"PEntityOfEntIndex" },		// pfnPEntityOfEntIndex
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"FindEntityByVars" },		// pfnFindEntityByVars
-	{ mFALSE,  14,	api_caller_ptr_args_p,		"GetModelPtr" },		// pfnGetModelPtr
-	{ mFALSE,  9,	api_caller_int_args_pi,		"RegUserMsg" },			// pfnRegUserMsg
-	{ mFALSE,  9,	api_caller_void_args_pf,	"AnimationAutomove" },		// pfnAnimationAutomove
-	{ mFALSE,  9,	api_caller_void_args_pi2p,	"GetBonePosition" },		// pfnGetBonePosition
-	{ mFALSE,  9,	api_caller_uint_args_p,		"FunctionFromName" },		// pfnFunctionFromName
-	{ mFALSE,  9,	api_caller_ptr_args_ui,		"NameForFunction" },		// pfnNameForFunction
-	{ mFALSE,  9,	api_caller_void_args_pip,	"ClientPrintf" },		// pfnClientPrintf
-	{ mFALSE,  9,	api_caller_void_args_p,		"ServerPrint" },		// pfnServerPrint
-	{ mFALSE,  13,	api_caller_ptr_args_void,	"Cmd_Args" },			// pfnCmd_Args
-	{ mFALSE,  13,	api_caller_ptr_args_i,		"Cmd_Argv" },			// pfnCmd_Argv
-	{ mFALSE,  13,	api_caller_int_args_void,	"Cmd_Argc" },			// pfnCmd_Argc
-	{ mFALSE,  9,	api_caller_void_args_pi2p,	"GetAttachment" },		// pfnGetAttachment
-	{ mFALSE,  9,	api_caller_void_args_p,		"CRC32_Init" },			// pfnCRC32_Init
-	{ mFALSE,  9,	api_caller_void_args_2pi,	"CRC32_ProcessBuffer" },	// pfnCRC32_ProcessBuffer
-	{ mFALSE,  9,	api_caller_void_args_puc,	"CRC32_ProcessByte" },		// pfnCRC32_ProcessByte
-	{ mFALSE,  9,	api_caller_ulong_args_ul,	"CRC32_Final" },		// pfnCRC32_Final
-	{ mFALSE,  16,	api_caller_int_args_2i,		"RandomLong" },			// pfnRandomLong
-	{ mFALSE,  14,	api_caller_float_args_2f,	"RandomFloat" },		// pfnRandomFloat		// CS: when firing
-	{ mFALSE,  14,	api_caller_void_args_2p,	"SetView" },			// pfnSetView
-	{ mFALSE,  9,	api_caller_float_args_void,	"Time" },			// pfnTime
-	{ mFALSE,  9,	api_caller_void_args_p2f,	"CrosshairAngle" },		// pfnCrosshairAngle
-	{ mFALSE,  10,	api_caller_ptr_args_2p,		"LoadFileForMe" },		// pfnLoadFileForMe
-	{ mFALSE,  10,	api_caller_void_args_p,		"FreeFile" },			// pfnFreeFile
-	{ mFALSE,  9,	api_caller_void_args_p,		"EndSection" },			// pfnEndSection
-	{ mFALSE,  9,	api_caller_int_args_3p,		"CompareFileTime" },		// pfnCompareFileTime
-	{ mFALSE,  9,	api_caller_void_args_p,		"GetGameDir" },			// pfnGetGameDir
-	{ mFALSE,  9,	api_caller_void_args_p,		"Cvar_RegisterVariable" },	// pfnCvar_RegisterVariable
-	{ mFALSE,  9,	api_caller_void_args_p4i,	"FadeClientVolume" },		// pfnFadeClientVolume
-	{ mFALSE,  14,	api_caller_void_args_pf,	"SetClientMaxspeed" },		// pfnSetClientMaxspeed
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"CreateFakeClient" },		// pfnCreateFakeClient
-	{ mFALSE,  9,	api_caller_void_args_2p3fus2uc,	"RunPlayerMove" },		// pfnRunPlayerMove
-	{ mFALSE,  9,	api_caller_int_args_void,	"NumberOfEntities" },		// pfnNumberOfEntities
-	{ mFALSE,  17,	api_caller_ptr_args_p,		"GetInfoKeyBuffer" },		// pfnGetInfoKeyBuffer
-	{ mFALSE,  13,	api_caller_ptr_args_2p,		"InfoKeyValue" },		// pfnInfoKeyValue
-	{ mFALSE,  9,	api_caller_void_args_3p,	"SetKeyValue" },		// pfnSetKeyValue
-	{ mFALSE,  12,	api_caller_void_args_i3p,	"SetClientKeyValue" },		// pfnSetClientKeyValue
-	{ mFALSE,  9,	api_caller_int_args_p,		"IsMapValid" },			// pfnIsMapValid
-	{ mFALSE,  9,	api_caller_void_args_p3i,	"StaticDecal" },		// pfnStaticDecal
-	{ mFALSE,  9,	api_caller_int_args_p,		"PrecacheGeneric" },		// pfnPrecacheGeneric
-	{ mFALSE,  10,	api_caller_int_args_p,		"GetPlayerUserId" },		// pfnGetPlayerUserId
-	{ mFALSE,  9,	api_caller_void_args_pip2f4i2p,	"BuildSoundMsg" },		// pfnBuildSoundMsg
-	{ mFALSE,  9,	api_caller_int_args_void,	"IsDedicatedServer" },		// pfnIsDedicatedServer
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"CVarGetPointer" },		// pfnCVarGetPointer
-	{ mFALSE,  9,	api_caller_uint_args_p,		"GetPlayerWONId" },		// pfnGetPlayerWONId
-	{ mFALSE,  9,	api_caller_void_args_2p,	"Info_RemoveKey" },		// pfnInfo_RemoveKey
-	{ mFALSE,  15,	api_caller_ptr_args_2p,		"GetPhysicsKeyValue" },		// pfnGetPhysicsKeyValue
-	{ mFALSE,  14,	api_caller_void_args_3p,	"SetPhysicsKeyValue" },		// pfnSetPhysicsKeyValue
-	{ mFALSE,  15,	api_caller_ptr_args_p,		"GetPhysicsInfoString" },	// pfnGetPhysicsInfoString
-	{ mFALSE,  13,	api_caller_ushort_args_ip,	"PrecacheEvent" },		// pfnPrecacheEvent
-	{ mFALSE,  9,	api_caller_void_args_ipusf2p2f4i,"PlaybackEvent" },		// pfnPlaybackEvent
-	{ mFALSE,  31,	api_caller_ptr_args_p,		"SetFatPVS" },			// pfnSetFatPVS
-	{ mFALSE,  31,	api_caller_ptr_args_p,		"SetFatPAS" },			// pfnSetFatPAS
-	{ mFALSE,  50,	api_caller_int_args_2p,		"CheckVisibility" },		// pfnCheckVisibility
-	{ mFALSE,  37,	api_caller_void_args_2p,	"DeltaSetField" },		// pfnDeltaSetField
-	{ mFALSE,  38,	api_caller_void_args_2p,	"DeltaUnsetField" },		// pfnDeltaUnsetField
-	{ mFALSE,  9,	api_caller_void_args_2p,	"DeltaAddEncoder" },		// pfnDeltaAddEncoder
-	{ mFALSE,  45,	api_caller_int_args_void,	"GetCurrentPlayer" },		// pfnGetCurrentPlayer
-	{ mFALSE,  14,	api_caller_int_args_p,		"CanSkipPlayer" },		// pfnCanSkipPlayer
-	{ mFALSE,  9,	api_caller_int_args_2p,		"DeltaFindField" },		// pfnDeltaFindField
-	{ mFALSE,  37,	api_caller_void_args_pi,	"DeltaSetFieldByIndex" },	// pfnDeltaSetFieldByIndex
-	{ mFALSE,  38,	api_caller_void_args_pi,	"DeltaUnsetFieldByIndex" },	// pfnDeltaUnsetFieldByIndex
-	{ mFALSE,  9,	api_caller_void_args_2i,	"SetGroupMask" },		// pfnSetGroupMask
-	{ mFALSE,  9,	api_caller_int_args_ip,		"engCreateInstancedBaseline" },	// pfnCreateInstancedBaseline		// d'oh, CreateInstancedBaseline in dllapi too
-	{ mFALSE,  9,	api_caller_void_args_2p,	"Cvar_DirectSet" },		// pfnCvar_DirectSet
-	{ mFALSE,  9,	api_caller_void_args_i3p,	"ForceUnmodified" },		// pfnForceUnmodified
-	{ mFALSE,  9,	api_caller_void_args_3p,	"GetPlayerStats" },		// pfnGetPlayerStats
-	{ mFALSE,  3,	api_caller_void_args_2p,	"AddServerCommand" },		// pfnAddServerCommand
+	{13,	api_caller_int_args_p,		"PrecacheModel" },		// pfnPrecacheModel
+	{13,	api_caller_int_args_p,		"PrecacheSound" },		// pfnPrecacheSound
+	{18,	api_caller_void_args_2p,	"SetModel" },			// pfnSetModel
+	{34,	api_caller_int_args_p,		"ModelIndex" },			// pfnModelIndex
+	{10,	api_caller_int_args_i,		"ModelFrames" },		// pfnModelFrames
+	{14,	api_caller_void_args_3p,	"SetSize" },			// pfnSetSize
+	{9,	api_caller_void_args_2p,	"ChangeLevel" },		// pfnChangeLevel
+	{9,	api_caller_void_args_p,		"GetSpawnParms" },		// pfnGetSpawnParms
+	{9,	api_caller_void_args_p,		"SaveSpawnParms" },		// pfnSaveSpawnParms
+	{9,	api_caller_float_args_p,	"VecToYaw" },			// pfnVecToYaw
+	{14,	api_caller_void_args_2p,	"VecToAngles" },		// pfnVecToAngles
+	{9,	api_caller_void_args_2pfi,	"MoveToOrigin" },		// pfnMoveToOrigin
+	{9,	api_caller_void_args_p,		"ChangeYaw" },			// pfnChangeYaw
+	{9,	api_caller_void_args_p,		"ChangePitch" },		// pfnChangePitch
+	{32,	api_caller_ptr_args_3p,		"FindEntityByString" },		// pfnFindEntityByString
+	{9,	api_caller_int_args_p,		"GetEntityIllum" },		// pfnGetEntityIllum
+	{9,	api_caller_ptr_args_2pf,	"FindEntityInSphere" },		// pfnFindEntityInSphere
+	{19,	api_caller_ptr_args_p,		"FindClientInPVS" },		// pfnFindClientInPVS
+	{9,	api_caller_ptr_args_p,		"EntitiesInPVS" },		// pfnEntitiesInPVS
+	{40,	api_caller_void_args_p,		"MakeVectors" },		// pfnMakeVectors
+	{9,	api_caller_void_args_4p,	"AngleVectors" },		// pfnAngleVectors
+	{13,	api_caller_ptr_args_void,	"CreateEntity" },		// pfnCreateEntity
+	{13,	api_caller_void_args_p,		"RemoveEntity" },		// pfnRemoveEntity
+	{13,	api_caller_ptr_args_i,		"CreateNamedEntity" },		// pfnCreateNamedEntity
+	{9,	api_caller_void_args_p,		"MakeStatic" },			// pfnMakeStatic
+	{9,	api_caller_int_args_p,		"EntIsOnFloor" },		// pfnEntIsOnFloor
+	{9,	api_caller_int_args_p,		"DropToFloor" },		// pfnDropToFloor
+	{9,	api_caller_int_args_p2fi,	"WalkMove" },			// pfnWalkMove
+	{14,	api_caller_void_args_2p,	"SetOrigin" },			// pfnSetOrigin
+	{12,	api_caller_void_args_pip2f2i,	"EmitSound" },			// pfnEmitSound
+	{12,	api_caller_void_args_3p2f2i,	"EmitAmbientSound" },		// pfnEmitAmbientSound
+	{20,	api_caller_void_args_2pi2p,	"TraceLine" },			// pfnTraceLine
+	{9,	api_caller_void_args_3p,	"TraceToss" },			// pfnTraceToss
+	{9,	api_caller_int_args_3pi2p,	"TraceMonsterHull" },		// pfnTraceMonsterHull
+	{9,	api_caller_void_args_2p2i2p,	"TraceHull" },			// pfnTraceHull
+	{9,	api_caller_void_args_2pi2p,	"TraceModel" },			// pfnTraceModel
+	{15,	api_caller_ptr_args_3p,		"TraceTexture" },		// pfnTraceTexture		// CS: when moving
+	{9,	api_caller_void_args_2pif2p,	"TraceSphere" },		// pfnTraceSphere
+	{9,	api_caller_void_args_pfp,	"GetAimVector" },		// pfnGetAimVector
+	{9,	api_caller_void_args_p,		"ServerCommand" },		// pfnServerCommand
+	{9,	api_caller_void_args_void,	"ServerExecute" },		// pfnServerExecute
+	{11,	api_caller_void_args_2pV,	"engClientCommand" },		// pfnClientCommand		// d'oh, ClientCommand in dllapi too
+	{9,	api_caller_void_args_2p2f,	"ParticleEffect" },		// pfnParticleEffect
+	{9,	api_caller_void_args_ip,	"LightStyle" },			// pfnLightStyle
+	{9,	api_caller_int_args_p,		"DecalIndex" },			// pfnDecalIndex
+	{15,	api_caller_int_args_p,		"PointContents" },		// pfnPointContents		// CS: when moving
+	{22,	api_caller_void_args_2i2p,	"MessageBegin" },		// pfnMessageBegin
+	{22,	api_caller_void_args_void,	"MessageEnd" },			// pfnMessageEnd
+	{30,	api_caller_void_args_i,		"WriteByte" },			// pfnWriteByte
+	{23,	api_caller_void_args_i,		"WriteChar" },			// pfnWriteChar
+	{24,	api_caller_void_args_i,		"WriteShort" },			// pfnWriteShort
+	{23,	api_caller_void_args_i,		"WriteLong" },			// pfnWriteLong
+	{23,	api_caller_void_args_f,		"WriteAngle" },			// pfnWriteAngle
+	{23,	api_caller_void_args_f,		"WriteCoord" },			// pfnWriteCoord
+	{25,	api_caller_void_args_p,		"WriteString" },		// pfnWriteString
+	{23,	api_caller_void_args_i,		"WriteEntity" },		// pfnWriteEntity
+	{9,	api_caller_void_args_p,		"CVarRegister" },		// pfnCVarRegister
+	{21,	api_caller_float_args_p,	"CVarGetFloat" },		// pfnCVarGetFloat
+	{9,	api_caller_ptr_args_p,		"CVarGetString" },		// pfnCVarGetString
+	{10,	api_caller_void_args_pf,	"CVarSetFloat" },		// pfnCVarSetFloat
+	{9,	api_caller_void_args_2p,	"CVarSetString" },		// pfnCVarSetString
+	{15,	api_caller_void_args_ipV,	"AlertMessage" },		// pfnAlertMessage
+	{17,	api_caller_void_args_2pV,	"EngineFprintf" },		// pfnEngineFprintf
+	{14,	api_caller_ptr_args_pi,		"PvAllocEntPrivateData" },	// pfnPvAllocEntPrivateData
+	{9,	api_caller_ptr_args_p,		"PvEntPrivateData" },		// pfnPvEntPrivateData
+	{9,	api_caller_void_args_p,		"FreeEntPrivateData" },		// pfnFreeEntPrivateData
+	{9,	api_caller_ptr_args_i,		"SzFromIndex" },		// pfnSzFromIndex
+	{10,	api_caller_int_args_p,		"AllocString" },		// pfnAllocString
+	{9,	api_caller_ptr_args_p,		"GetVarsOfEnt" },		// pfnGetVarsOfEnt
+	{14,	api_caller_ptr_args_i,		"PEntityOfEntOffset" },		// pfnPEntityOfEntOffset
+	{19,	api_caller_int_args_p,		"EntOffsetOfPEntity" },		// pfnEntOffsetOfPEntity
+	{14,	api_caller_int_args_p,		"IndexOfEdict" },		// pfnIndexOfEdict
+	{17,	api_caller_ptr_args_i,		"PEntityOfEntIndex" },		// pfnPEntityOfEntIndex
+	{9,	api_caller_ptr_args_p,		"FindEntityByVars" },		// pfnFindEntityByVars
+	{14,	api_caller_ptr_args_p,		"GetModelPtr" },		// pfnGetModelPtr
+	{9,	api_caller_int_args_pi,		"RegUserMsg" },			// pfnRegUserMsg
+	{9,	api_caller_void_args_pf,	"AnimationAutomove" },		// pfnAnimationAutomove
+	{9,	api_caller_void_args_pi2p,	"GetBonePosition" },		// pfnGetBonePosition
+	{9,	api_caller_uint_args_p,		"FunctionFromName" },		// pfnFunctionFromName
+	{9,	api_caller_ptr_args_ui,		"NameForFunction" },		// pfnNameForFunction
+	{9,	api_caller_void_args_pip,	"ClientPrintf" },		// pfnClientPrintf
+	{9,	api_caller_void_args_p,		"ServerPrint" },		// pfnServerPrint
+	{13,	api_caller_ptr_args_void,	"Cmd_Args" },			// pfnCmd_Args
+	{13,	api_caller_ptr_args_i,		"Cmd_Argv" },			// pfnCmd_Argv
+	{13,	api_caller_int_args_void,	"Cmd_Argc" },			// pfnCmd_Argc
+	{9,	api_caller_void_args_pi2p,	"GetAttachment" },		// pfnGetAttachment
+	{9,	api_caller_void_args_p,		"CRC32_Init" },			// pfnCRC32_Init
+	{9,	api_caller_void_args_2pi,	"CRC32_ProcessBuffer" },	// pfnCRC32_ProcessBuffer
+	{9,	api_caller_void_args_puc,	"CRC32_ProcessByte" },		// pfnCRC32_ProcessByte
+	{9,	api_caller_ulong_args_ul,	"CRC32_Final" },		// pfnCRC32_Final
+	{16,	api_caller_int_args_2i,		"RandomLong" },			// pfnRandomLong
+	{14,	api_caller_float_args_2f,	"RandomFloat" },		// pfnRandomFloat		// CS: when firing
+	{14,	api_caller_void_args_2p,	"SetView" },			// pfnSetView
+	{9,	api_caller_float_args_void,	"Time" },			// pfnTime
+	{9,	api_caller_void_args_p2f,	"CrosshairAngle" },		// pfnCrosshairAngle
+	{10,	api_caller_ptr_args_2p,		"LoadFileForMe" },		// pfnLoadFileForMe
+	{10,	api_caller_void_args_p,		"FreeFile" },			// pfnFreeFile
+	{9,	api_caller_void_args_p,		"EndSection" },			// pfnEndSection
+	{9,	api_caller_int_args_3p,		"CompareFileTime" },		// pfnCompareFileTime
+	{9,	api_caller_void_args_p,		"GetGameDir" },			// pfnGetGameDir
+	{9,	api_caller_void_args_p,		"Cvar_RegisterVariable" },	// pfnCvar_RegisterVariable
+	{9,	api_caller_void_args_p4i,	"FadeClientVolume" },		// pfnFadeClientVolume
+	{14,	api_caller_void_args_pf,	"SetClientMaxspeed" },		// pfnSetClientMaxspeed
+	{9,	api_caller_ptr_args_p,		"CreateFakeClient" },		// pfnCreateFakeClient
+	{9,	api_caller_void_args_2p3fus2uc,	"RunPlayerMove" },		// pfnRunPlayerMove
+	{9,	api_caller_int_args_void,	"NumberOfEntities" },		// pfnNumberOfEntities
+	{17,	api_caller_ptr_args_p,		"GetInfoKeyBuffer" },		// pfnGetInfoKeyBuffer
+	{13,	api_caller_ptr_args_2p,		"InfoKeyValue" },		// pfnInfoKeyValue
+	{9,	api_caller_void_args_3p,	"SetKeyValue" },		// pfnSetKeyValue
+	{12,	api_caller_void_args_i3p,	"SetClientKeyValue" },		// pfnSetClientKeyValue
+	{9,	api_caller_int_args_p,		"IsMapValid" },			// pfnIsMapValid
+	{9,	api_caller_void_args_p3i,	"StaticDecal" },		// pfnStaticDecal
+	{9,	api_caller_int_args_p,		"PrecacheGeneric" },		// pfnPrecacheGeneric
+	{10,	api_caller_int_args_p,		"GetPlayerUserId" },		// pfnGetPlayerUserId
+	{9,	api_caller_void_args_pip2f4i2p,	"BuildSoundMsg" },		// pfnBuildSoundMsg
+	{9,	api_caller_int_args_void,	"IsDedicatedServer" },		// pfnIsDedicatedServer
+	{9,	api_caller_ptr_args_p,		"CVarGetPointer" },		// pfnCVarGetPointer
+	{9,	api_caller_uint_args_p,		"GetPlayerWONId" },		// pfnGetPlayerWONId
+	{9,	api_caller_void_args_2p,	"Info_RemoveKey" },		// pfnInfo_RemoveKey
+	{15,	api_caller_ptr_args_2p,		"GetPhysicsKeyValue" },		// pfnGetPhysicsKeyValue
+	{14,	api_caller_void_args_3p,	"SetPhysicsKeyValue" },		// pfnSetPhysicsKeyValue
+	{15,	api_caller_ptr_args_p,		"GetPhysicsInfoString" },	// pfnGetPhysicsInfoString
+	{13,	api_caller_ushort_args_ip,	"PrecacheEvent" },		// pfnPrecacheEvent
+	{9,	api_caller_void_args_ipusf2p2f4i,"PlaybackEvent" },		// pfnPlaybackEvent
+	{31,	api_caller_ptr_args_p,		"SetFatPVS" },			// pfnSetFatPVS
+	{31,	api_caller_ptr_args_p,		"SetFatPAS" },			// pfnSetFatPAS
+	{50,	api_caller_int_args_2p,		"CheckVisibility" },		// pfnCheckVisibility
+	{37,	api_caller_void_args_2p,	"DeltaSetField" },		// pfnDeltaSetField
+	{38,	api_caller_void_args_2p,	"DeltaUnsetField" },		// pfnDeltaUnsetField
+	{9,	api_caller_void_args_2p,	"DeltaAddEncoder" },		// pfnDeltaAddEncoder
+	{45,	api_caller_int_args_void,	"GetCurrentPlayer" },		// pfnGetCurrentPlayer
+	{14,	api_caller_int_args_p,		"CanSkipPlayer" },		// pfnCanSkipPlayer
+	{9,	api_caller_int_args_2p,		"DeltaFindField" },		// pfnDeltaFindField
+	{37,	api_caller_void_args_pi,	"DeltaSetFieldByIndex" },	// pfnDeltaSetFieldByIndex
+	{38,	api_caller_void_args_pi,	"DeltaUnsetFieldByIndex" },	// pfnDeltaUnsetFieldByIndex
+	{9,	api_caller_void_args_2i,	"SetGroupMask" },		// pfnSetGroupMask
+	{9,	api_caller_int_args_ip,		"engCreateInstancedBaseline" },	// pfnCreateInstancedBaseline		// d'oh, CreateInstancedBaseline in dllapi too
+	{9,	api_caller_void_args_2p,	"Cvar_DirectSet" },		// pfnCvar_DirectSet
+	{9,	api_caller_void_args_i3p,	"ForceUnmodified" },		// pfnForceUnmodified
+	{9,	api_caller_void_args_3p,	"GetPlayerStats" },		// pfnGetPlayerStats
+	{3,	api_caller_void_args_2p,	"AddServerCommand" },		// pfnAddServerCommand
 	// Added in SDK 2.2:
-	{ mFALSE,  9,	api_caller_int_args_2i,		"Voice_GetClientListening" },	// Voice_GetClientListening
-	{ mFALSE,  9,	api_caller_int_args_3i,		"Voice_SetClientListening" },	// Voice_SetClientListening
+	{9,	api_caller_int_args_2i,		"Voice_GetClientListening" },	// Voice_GetClientListening
+	{9,	api_caller_int_args_3i,		"Voice_SetClientListening" },	// Voice_SetClientListening
 	// Added for HL 1109 (no SDK update):
-	{ mFALSE,  9,	api_caller_ptr_args_p,		"GetPlayerAuthId" },		// pfnGetPlayerAuthId
+	{9,	api_caller_ptr_args_p,		"GetPlayerAuthId" },		// pfnGetPlayerAuthId
 	// Added 2003/11/10 (no SDK update):
-	{ mFALSE,  30,	api_caller_ptr_args_2p,		"SequenceGet" },		// pfnSequenceGet
-	{ mFALSE,  30,	api_caller_ptr_args_pip,	"SequencePickSentence" },	// pfnSequencePickSentence
-	{ mFALSE,  30,	api_caller_int_args_p,		"GetFileSize" },		// pfnGetFileSize
-	{ mFALSE,  30,	api_caller_uint_args_p,		"GetApproxWavePlayLen" },	// pfnGetApproxWavePlayLen
-	{ mFALSE,  30,	api_caller_int_args_void,	"IsCareerMatch" },		// pfnIsCareerMatch
-	{ mFALSE,  30,	api_caller_int_args_p,		"GetLocalizedStringLength" },	// pfnGetLocalizedStringLength
-	{ mFALSE,  30,	api_caller_void_args_i,		"RegisterTutorMessageShown" },	// pfnRegisterTutorMessageShown
-	{ mFALSE,  30,	api_caller_int_args_i,		"GetTimesTutorMessageShown" },	// pfnGetTimesTutorMessageShown
-	{ mFALSE,  30,	api_caller_void_args_pi,	"ProcessTutorMessageDecayBuffer" },	// pfnProcessTutorMessageDecayBuffer
-	{ mFALSE,  30,	api_caller_void_args_pi,	"ConstructTutorMessageDecayBuffer" },	// pfnConstructTutorMessageDecayBuffer
-	{ mFALSE,  9,	api_caller_void_args_void,	"ResetTutorMessageDecayData" },	// pfnResetTutorMessageDecayData
+	{30,	api_caller_ptr_args_2p,		"SequenceGet" },		// pfnSequenceGet
+	{30,	api_caller_ptr_args_pip,	"SequencePickSentence" },	// pfnSequencePickSentence
+	{30,	api_caller_int_args_p,		"GetFileSize" },		// pfnGetFileSize
+	{30,	api_caller_uint_args_p,		"GetApproxWavePlayLen" },	// pfnGetApproxWavePlayLen
+	{30,	api_caller_int_args_void,	"IsCareerMatch" },		// pfnIsCareerMatch
+	{30,	api_caller_int_args_p,		"GetLocalizedStringLength" },	// pfnGetLocalizedStringLength
+	{30,	api_caller_void_args_i,		"RegisterTutorMessageShown" },	// pfnRegisterTutorMessageShown
+	{30,	api_caller_int_args_i,		"GetTimesTutorMessageShown" },	// pfnGetTimesTutorMessageShown
+	{30,	api_caller_void_args_pi,	"ProcessTutorMessageDecayBuffer" },	// pfnProcessTutorMessageDecayBuffer
+	{30,	api_caller_void_args_pi,	"ConstructTutorMessageDecayBuffer" },	// pfnConstructTutorMessageDecayBuffer
+	{9,	api_caller_void_args_void,	"ResetTutorMessageDecayData" },	// pfnResetTutorMessageDecayData
 	// Added 2005/08/11 (no SDK update):
-	{ mFALSE,  3,	api_caller_void_args_2p,	"QueryClientCvarValue" },	// pfnQueryClientCvarValue
+	{3,	api_caller_void_args_2p,	"QueryClientCvarValue" },	// pfnQueryClientCvarValue
 	// Added 2005/11/21 (no SDK update):
-	{ mFALSE,  3,	api_caller_void_args_2pi,	"QueryClientCvarValue2" },	// pfnQueryClientCvarValue2
+	{3,	api_caller_void_args_2pi,	"QueryClientCvarValue2" },	// pfnQueryClientCvarValue2
 	// Added 2009-06-17 (no SDK update):
-	{ mFALSE,  8,	api_caller_int_args_2p,		"EngCheckParm" },		// pfnEngCheckParm
+	{8,	api_caller_int_args_2p,		"EngCheckParm" },		// pfnEngCheckParm
 	// end
-	{ mFALSE,  0,   NULL,	NULL },
+	{0,   NULL,	NULL },
 };

--- a/metamod/api_info.h
+++ b/metamod/api_info.h
@@ -58,7 +58,6 @@ typedef void * (DLLINTERNAL_NOVIS * api_caller_func_t)(const void * func, const 
 
 
 typedef struct api_info_s {
-	mBOOL trace;			// if true, log info about this function
 	int loglevel;			// level at which to log info about this function
 	api_caller_func_t api_caller;	// argument format/type for single-main-hook-function optimization
 	const char *name;		// string representation of function name

--- a/metamod/comp_dep.h
+++ b/metamod/comp_dep.h
@@ -96,6 +96,17 @@
 	#define FORCE_STACK_ALIGN
 #endif
 
+// Optimize hot dispatch functions: skip stack canary, hint for aggressive optimization
+#if defined(__clang__) && __clang_major__ >= 7
+	#define HOT_FUNC __attribute__((hot, no_stack_protector))
+#elif defined(__GNUC__) && __GNUC__ >= 11
+	#define HOT_FUNC __attribute__((hot, no_stack_protector))
+#elif defined(__GNUC__)
+	#define HOT_FUNC __attribute__((hot))
+#else
+	#define HOT_FUNC
+#endif
+
 // Prevent function inlining to reduce code size at call sites
 #if defined(__GNUC__)
 	#define NOINLINE __attribute__((noinline))

--- a/metamod/comp_dep.h
+++ b/metamod/comp_dep.h
@@ -114,6 +114,15 @@
 	#define NOINLINE
 #endif
 
+// Place hot-path data in dedicated sections for cache locality
+#if defined(__GNUC__)
+	#define HOT_DATA __attribute__((section(".data.hot_data")))
+	#define HOT_RODATA __attribute__((section(".data.hot_rodata")))
+#else
+	#define HOT_DATA
+	#define HOT_RODATA
+#endif
+
 // Manual branch optimization for GCC 3.0.0 and newer
 #if !defined(__GNUC__) || __GNUC__ < 3
 	#define likely(x) (x)

--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -500,7 +500,7 @@ C_DLLEXPORT FORCE_STACK_ALIGN int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunc
 	// Don't provide these functions to engine if gamedll doesn't provide
 	// them.  Otherwise, we're in the position of having to provide answers
 	// we can't necessarily provide (for instance, ShouldCollide())...
-	if(!GameDLL.funcs.newapi_table)
+	if(!GameDLL_funcs.newapi_table)
 		return(FALSE);
 #endif
 

--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -76,111 +76,116 @@
 
 
 // From SDK dlls/game.cpp:
-static FORCE_STACK_ALIGN void mm_GameDLLInit(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GameDLLInit(void) {
 	META_DLLAPI_HANDLE_void(FN_GAMEINIT, pfnGameInit, void, (VOID_ARG));
 	RETURN_API_void();
 }
 
 // From SDK dlls/cbase.cpp:
-static FORCE_STACK_ALIGN int mm_DispatchSpawn(edict_t *pent) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_DispatchSpawn(edict_t *pent) {
 	// 0==Success, -1==Failure ?
 	META_DLLAPI_HANDLE(int, 0, FN_DISPATCHSPAWN, pfnSpawn, p, (pent));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN void mm_DispatchThink(edict_t *pent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchThink(edict_t *pent) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHTHINK, pfnThink, p, (pent));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_DispatchUse(edict_t *pentUsed, edict_t *pentOther) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchUse(edict_t *pentUsed, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHUSE, pfnUse, 2p, (pentUsed, pentOther));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_DispatchTouch(edict_t *pentTouched, edict_t *pentOther) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchTouch(edict_t *pentTouched, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHTOUCH, pfnTouch, 2p, (pentTouched, pentOther));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_DispatchBlocked(edict_t *pentBlocked, edict_t *pentOther) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchBlocked(edict_t *pentBlocked, edict_t *pentOther) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHBLOCKED, pfnBlocked, 2p, (pentBlocked, pentOther));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_DispatchKeyValue(edict_t *pentKeyvalue, KeyValueData *pkvd) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchKeyValue(edict_t *pentKeyvalue, KeyValueData *pkvd) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHKEYVALUE, pfnKeyValue, 2p, (pentKeyvalue, pkvd));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_DispatchSave(edict_t *pent, SAVERESTOREDATA *pSaveData) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchSave(edict_t *pent, SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHSAVE, pfnSave, 2p, (pent, pSaveData));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_DispatchRestore(edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_DispatchRestore(edict_t *pent, SAVERESTOREDATA *pSaveData, int globalEntity) {
 	// 0==Success, -1==Failure ?
 	META_DLLAPI_HANDLE(int, 0, FN_DISPATCHRESTORE, pfnRestore, 2pi, (pent, pSaveData, globalEntity));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN void mm_DispatchObjectCollisionBox(edict_t *pent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DispatchObjectCollisionBox(edict_t *pent) {
 	META_DLLAPI_HANDLE_void(FN_DISPATCHOBJECTCOLLISIONBOX, pfnSetAbsBox, p, (pent));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_SaveWriteFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SaveWriteFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
 	META_DLLAPI_HANDLE_void(FN_SAVEWRITEFIELDS, pfnSaveWriteFields, 4pi, (pSaveData, pname, pBaseData, pFields, fieldCount));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_SaveReadFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SaveReadFields(SAVERESTOREDATA *pSaveData, const char *pname, void *pBaseData, TYPEDESCRIPTION *pFields, int fieldCount) {
 	META_DLLAPI_HANDLE_void(FN_SAVEREADFIELDS, pfnSaveReadFields, 4pi, (pSaveData, pname, pBaseData, pFields, fieldCount));
 	RETURN_API_void();
 }
 
 // From SDK dlls/world.cpp:
-static FORCE_STACK_ALIGN void mm_SaveGlobalState(SAVERESTOREDATA *pSaveData) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SaveGlobalState(SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_SAVEGLOBALSTATE, pfnSaveGlobalState, p, (pSaveData));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_RestoreGlobalState(SAVERESTOREDATA *pSaveData) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_RestoreGlobalState(SAVERESTOREDATA *pSaveData) {
 	META_DLLAPI_HANDLE_void(FN_RESTOREGLOBALSTATE, pfnRestoreGlobalState, p, (pSaveData));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ResetGlobalState(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ResetGlobalState(void) {
 	META_DLLAPI_HANDLE_void(FN_RESETGLOBALSTATE, pfnResetGlobalState, void, (VOID_ARG));
 	RETURN_API_void();
 }
 
 // From SDK dlls/client.cpp:
-static FORCE_STACK_ALIGN qboolean mm_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]) {
+static NOINLINE void do_clear_player_cvar_query(const edict_t *pEntity) {
 	g_Players.clear_player_cvar_query(pEntity);
+}
+static HOT_FUNC FORCE_STACK_ALIGN qboolean mm_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]) {
+	do_clear_player_cvar_query(pEntity);
 	META_DLLAPI_HANDLE(qboolean, TRUE, FN_CLIENTCONNECT, pfnClientConnect, 4p, (pEntity, pszName, pszAddress, szRejectReason));
 	RETURN_API(qboolean);
 }
-static FORCE_STACK_ALIGN void mm_ClientDisconnect(edict_t *pEntity) {
-	g_Players.clear_player_cvar_query(pEntity);
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientDisconnect(edict_t *pEntity) {
+	do_clear_player_cvar_query(pEntity);
 	META_DLLAPI_HANDLE_void(FN_CLIENTDISCONNECT, pfnClientDisconnect, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ClientKill(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientKill(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTKILL, pfnClientKill, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ClientPutInServer(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientPutInServer(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTPUTINSERVER, pfnClientPutInServer, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ClientCommand(edict_t *pEntity) {
+static NOINLINE void metamod_ClientCommand(edict_t *pEntity) {
 	if(Config->clientmeta && strmatch(CMD_ARGV(0), "meta")) {
 		client_meta(pEntity);
 	}
+}
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientCommand(edict_t *pEntity) {
+	metamod_ClientCommand(pEntity);
 	META_DLLAPI_HANDLE_void(FN_CLIENTCOMMAND, pfnClientCommand, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ClientUserInfoChanged(edict_t *pEntity, char *infobuffer) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientUserInfoChanged(edict_t *pEntity, char *infobuffer) {
 	META_DLLAPI_HANDLE_void(FN_CLIENTUSERINFOCHANGED, pfnClientUserInfoChanged, 2p, (pEntity, infobuffer));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax) {
 	META_DLLAPI_HANDLE_void(FN_SERVERACTIVATE, pfnServerActivate, p2i, (pEdictList, edictCount, clientMax));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ServerDeactivate(void) {
-	META_DLLAPI_HANDLE_void(FN_SERVERDEACTIVATE, pfnServerDeactivate, void, (VOID_ARG));
+static NOINLINE void metamod_ServerDeactivate(void) {
 	// Update loaded plugins.  Look for new plugins in inifile, as well as
-	// any plugins waiting for a changelevel to load.  
+	// any plugins waiting for a changelevel to load.
 	//
 	// This is done in ServerDeactivate rather than Activate, as the latter
 	// isn't actually the first routine to be called on a new map.  In
@@ -197,119 +202,123 @@ static FORCE_STACK_ALIGN void mm_ServerDeactivate(void) {
 	// Plugins->retry_all(PT_CHANGELEVEL);
 	g_Players.clear_all_cvar_queries();
 	requestid_counter = 0;
+}
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ServerDeactivate(void) {
+	META_DLLAPI_HANDLE_void(FN_SERVERDEACTIVATE, pfnServerDeactivate, void, (VOID_ARG));
+	metamod_ServerDeactivate();
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_PlayerPreThink(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PlayerPreThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERPRETHINK, pfnPlayerPreThink, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_PlayerPostThink(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PlayerPostThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERPOSTTHINK, pfnPlayerPostThink, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_StartFrame(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_StartFrame(void) {
 	meta_debug_value = (int)meta_debug.value;
 
 	META_DLLAPI_HANDLE_void(FN_STARTFRAME, pfnStartFrame, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ParmsNewLevel(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ParmsNewLevel(void) {
 	META_DLLAPI_HANDLE_void(FN_PARMSNEWLEVEL, pfnParmsNewLevel, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_ParmsChangeLevel(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ParmsChangeLevel(void) {
 	META_DLLAPI_HANDLE_void(FN_PARMSCHANGELEVEL, pfnParmsChangeLevel, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN const char *mm_GetGameDescription(void) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_GetGameDescription(void) {
 	META_DLLAPI_HANDLE(const char *, NULL, FN_GETGAMEDESCRIPTION, pfnGetGameDescription, void, (VOID_ARG));
 	RETURN_API(const char *);
 }
-static FORCE_STACK_ALIGN void mm_PlayerCustomization(edict_t *pEntity, customization_t *pCust) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PlayerCustomization(edict_t *pEntity, customization_t *pCust) {
 	META_DLLAPI_HANDLE_void(FN_PLAYERCUSTOMIZATION, pfnPlayerCustomization, 2p, (pEntity, pCust));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_SpectatorConnect(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SpectatorConnect(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORCONNECT, pfnSpectatorConnect, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_SpectatorDisconnect(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SpectatorDisconnect(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORDISCONNECT, pfnSpectatorDisconnect, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_SpectatorThink(edict_t *pEntity) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SpectatorThink(edict_t *pEntity) {
 	META_DLLAPI_HANDLE_void(FN_SPECTATORTHINK, pfnSpectatorThink, p, (pEntity));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_Sys_Error(const char *error_string) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_Sys_Error(const char *error_string) {
 	META_DLLAPI_HANDLE_void(FN_SYS_ERROR, pfnSys_Error, p, (error_string));
 	RETURN_API_void();
 }
 
 // From SDK pm_shared/pm_shared.c:
-static FORCE_STACK_ALIGN void mm_PM_Move (struct playermove_s *ppmove, int server) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PM_Move (struct playermove_s *ppmove, int server) {
 	META_DLLAPI_HANDLE_void(FN_PM_MOVE, pfnPM_Move, pi, (ppmove, server));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_PM_Init(struct playermove_s *ppmove) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PM_Init(struct playermove_s *ppmove) {
 	META_DLLAPI_HANDLE_void(FN_PM_INIT, pfnPM_Init, p, (ppmove));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN char mm_PM_FindTextureType(char *name) {
+static HOT_FUNC FORCE_STACK_ALIGN char mm_PM_FindTextureType(char *name) {
 	META_DLLAPI_HANDLE(char, '\0', FN_PM_FINDTEXTURETYPE, pfnPM_FindTextureType, p, (name));
 	RETURN_API(char);
 }
 
 // From SDK dlls/client.cpp:
-static FORCE_STACK_ALIGN void mm_SetupVisibility(edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetupVisibility(edict_t *pViewEntity, edict_t *pClient, unsigned char **pvs, unsigned char **pas) {
 	META_DLLAPI_HANDLE_void(FN_SETUPVISIBILITY, pfnSetupVisibility, 4p, (pViewEntity, pClient, pvs, pas));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_UpdateClientData (const struct edict_s *ent, int sendweapons, struct clientdata_s *cd) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_UpdateClientData (const struct edict_s *ent, int sendweapons, struct clientdata_s *cd) {
 	META_DLLAPI_HANDLE_void(FN_UPDATECLIENTDATA, pfnUpdateClientData, pip, (ent, sendweapons, cd));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_AddToFullPack(struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_AddToFullPack(struct entity_state_s *state, int e, edict_t *ent, edict_t *host, int hostflags, int player, unsigned char *pSet) {
 	META_DLLAPI_HANDLE(int, 0, FN_ADDTOFULLPACK, pfnAddToFullPack, pi2p2ip, (state, e, ent, host, hostflags, player, pSet));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN void mm_CreateBaseline(int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CreateBaseline(int player, int eindex, struct entity_state_s *baseline, struct edict_s *entity, int playermodelindex, vec3_t player_mins, vec3_t player_maxs) {
 	META_DLLAPI_HANDLE_void(FN_CREATEBASELINE, pfnCreateBaseline, 2i2pi2p, (player, eindex, baseline, entity, playermodelindex, (float*)player_mins, (float*)player_maxs));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_RegisterEncoders(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_RegisterEncoders(void) {
 	META_DLLAPI_HANDLE_void(FN_REGISTERENCODERS, pfnRegisterEncoders, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_GetWeaponData(struct edict_s *player, struct weapon_data_s *info) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetWeaponData(struct edict_s *player, struct weapon_data_s *info) {
 	META_DLLAPI_HANDLE(int, 0, FN_GETWEAPONDATA, pfnGetWeaponData, 2p, (player, info));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN void mm_CmdStart(const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CmdStart(const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed) {
 	META_DLLAPI_HANDLE_void(FN_CMDSTART, pfnCmdStart, 2pui, (player, cmd, random_seed));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_CmdEnd (const edict_t *player) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CmdEnd (const edict_t *player) {
 	META_DLLAPI_HANDLE_void(FN_CMDEND, pfnCmdEnd, p, (player));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_ConnectionlessPacket(const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_ConnectionlessPacket(const struct netadr_s *net_from, const char *args, char *response_buffer, int *response_buffer_size) {
 	META_DLLAPI_HANDLE(int, 0, FN_CONNECTIONLESSPACKET, pfnConnectionlessPacket, 4p, (net_from, args, response_buffer, response_buffer_size));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN int mm_GetHullBounds(int hullnumber, float *mins, float *maxs) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetHullBounds(int hullnumber, float *mins, float *maxs) {
 	META_DLLAPI_HANDLE(int, 0, FN_GETHULLBOUNDS, pfnGetHullBounds, i2p, (hullnumber, mins, maxs));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN void mm_CreateInstancedBaselines (void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CreateInstancedBaselines (void) {
 	META_DLLAPI_HANDLE_void(FN_CREATEINSTANCEDBASELINES, pfnCreateInstancedBaselines, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_InconsistentFile(const edict_t *player, const char *filename, char *disconnect_message) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_InconsistentFile(const edict_t *player, const char *filename, char *disconnect_message) {
 	META_DLLAPI_HANDLE(int, 0, FN_INCONSISTENTFILE, pfnInconsistentFile, 3p, (player, filename, disconnect_message));
 	RETURN_API(int);
 }
-static FORCE_STACK_ALIGN int mm_AllowLagCompensation(void) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_AllowLagCompensation(void) {
 	META_DLLAPI_HANDLE(int, 0, FN_ALLOWLAGCOMPENSATION, pfnAllowLagCompensation, void, (VOID_ARG));
 	RETURN_API(int);
 }
@@ -317,27 +326,27 @@ static FORCE_STACK_ALIGN int mm_AllowLagCompensation(void) {
 
 // New API functions
 // From SDK ?
-static FORCE_STACK_ALIGN void mm_OnFreeEntPrivateData(edict_t *pEnt) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_OnFreeEntPrivateData(edict_t *pEnt) {
 	META_NEWAPI_HANDLE_void(FN_ONFREEENTPRIVATEDATA, pfnOnFreeEntPrivateData, p, (pEnt));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN void mm_GameShutdown(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GameShutdown(void) {
 	META_NEWAPI_HANDLE_void(FN_GAMESHUTDOWN, pfnGameShutdown, void, (VOID_ARG));
 	RETURN_API_void();
 }
-static FORCE_STACK_ALIGN int mm_ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_ShouldCollide(edict_t *pentTouched, edict_t *pentOther) {
 	META_NEWAPI_HANDLE(int, 1, FN_SHOULDCOLLIDE, pfnShouldCollide, 2p, (pentTouched, pentOther));
 	RETURN_API(int);
 }
 // Added 2005/08/11 (no SDK update):
-static FORCE_STACK_ALIGN void mm_CvarValue(const edict_t *pEnt, const char *value) {
-	g_Players.clear_player_cvar_query(pEnt);
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CvarValue(const edict_t *pEnt, const char *value) {
+	do_clear_player_cvar_query(pEnt);
 	META_NEWAPI_HANDLE_void(FN_CVARVALUE, pfnCvarValue, 2p, (pEnt, value));
 	
 	RETURN_API_void();
 }
 // Added 2005/11/21 (no SDK update):
-static FORCE_STACK_ALIGN void mm_CvarValue2(const edict_t *pEnt, int requestID, const char *cvarName, const char *value) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CvarValue2(const edict_t *pEnt, int requestID, const char *cvarName, const char *value) {
 	META_NEWAPI_HANDLE_void(FN_CVARVALUE2, pfnCvarValue2, pi2p, (pEnt, requestID, cvarName, value));
 	
 	RETURN_API_void();

--- a/metamod/engine_api.cpp
+++ b/metamod/engine_api.cpp
@@ -65,26 +65,33 @@
 
 // For varargs functions
 #ifndef DO_NOT_FIX_VARARG_ENGINE_API_WARPERS
+	static void DLLINTERNAL eng_make_formated_string(char **pbuf, size_t buflen, const char *format, va_list ap) {
+		char *buf=*pbuf;
+		int len;
+		va_list vargs1;
+		va_list vargs2;
+		va_copy(vargs1, ap);
+		len = safe_vsnprintf(buf, buflen, format, vargs1);
+		va_end(vargs1);
+		if((unsigned)len >= buflen) {
+			buf = (char *)malloc(len + 1);
+			if(buf) {
+				va_copy(vargs2, ap);
+				safevoid_vsnprintf(buf, len + 1, format, vargs2);
+				va_end(vargs2);
+			} else {
+				buf=*pbuf;
+			}
+		}
+		*pbuf=buf;
+	}
 	#define MAKE_FORMATED_STRING(szFmt) \
 		char strbuf[MAX_STRBUF_LEN]; \
 		char * buf=strbuf; \
-		{ \
-			int len; \
-			va_list vargs; \
-			va_start(vargs, szFmt); \
-			len = safe_vsnprintf(strbuf, sizeof(strbuf), szFmt, vargs); \
-			va_end(vargs); \
-			if((unsigned)len >= sizeof(strbuf)) { \
-				buf = (char *)malloc(len + 1); \
-				if(buf) { \
-					va_start(vargs, szFmt); \
-					safevoid_vsnprintf(buf, len + 1, szFmt, vargs); \
-					va_end(vargs); \
-				} else { \
-					buf=strbuf; \
-				} \
-			} \
-		}
+		va_list ap; \
+		va_start(ap, szFmt); \
+		eng_make_formated_string(&buf, sizeof(strbuf), szFmt, ap); \
+		va_end(ap);
 	#define CLEAN_FORMATED_STRING() \
 		if(buf != strbuf) \
 			free(buf);
@@ -95,7 +102,6 @@
 		va_start(ap, szFmt); \
 		safevoid_vsnprintf(buf, sizeof(buf), szFmt, ap); \
 		va_end(ap);
-	
 	#define CLEAN_FORMATED_STRING()
 #endif
 
@@ -120,264 +126,264 @@
 	CLEAN_FORMATED_STRING()
 
 
-static FORCE_STACK_ALIGN int mm_PrecacheModel(char *s) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_PrecacheModel(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHEMODEL, pfnPrecacheModel, p, (s));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_PrecacheSound(char *s) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_PrecacheSound(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHESOUND, pfnPrecacheSound, p, (s));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_SetModel(edict_t *e, const char *m) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetModel(edict_t *e, const char *m) {
 	META_ENGINE_HANDLE_void(FN_SETMODEL, pfnSetModel, 2p, (e, m));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_ModelIndex(const char *m) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_ModelIndex(const char *m) {
 	META_ENGINE_HANDLE(int, 0, FN_MODELINDEX, pfnModelIndex, p, (m));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_ModelFrames(int modelIndex) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_ModelFrames(int modelIndex) {
 	META_ENGINE_HANDLE(int, 0, FN_MODELFRAMES, pfnModelFrames, i, (modelIndex));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetSize(edict_t *e, const float *rgflMin, const float *rgflMax) {
 	META_ENGINE_HANDLE_void(FN_SETSIZE, pfnSetSize, 3p, (e, rgflMin, rgflMax));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_ChangeLevel(char *s1, char *s2) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ChangeLevel(char *s1, char *s2) {
 	META_ENGINE_HANDLE_void(FN_CHANGELEVEL, pfnChangeLevel, 2p, (s1, s2));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_GetSpawnParms(edict_t *ent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetSpawnParms(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_GETSPAWNPARMS, pfnGetSpawnParms, p, (ent));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_SaveSpawnParms(edict_t *ent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SaveSpawnParms(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_SAVESPAWNPARMS, pfnSaveSpawnParms, p, (ent));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN float mm_VecToYaw(const float *rgflVector) {
+static HOT_FUNC FORCE_STACK_ALIGN float mm_VecToYaw(const float *rgflVector) {
 	META_ENGINE_HANDLE(float, 0.0, FN_VECTOYAW, pfnVecToYaw, p, (rgflVector));
 	RETURN_API(float)
 }
-static FORCE_STACK_ALIGN void mm_VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_VecToAngles(const float *rgflVectorIn, float *rgflVectorOut) {
 	META_ENGINE_HANDLE_void(FN_VECTOANGLES, pfnVecToAngles, 2p, (rgflVectorIn, rgflVectorOut));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_MoveToOrigin(edict_t *ent, const float *pflGoal, float dist, int iMoveType) {
 	META_ENGINE_HANDLE_void(FN_MOVETOORIGIN, pfnMoveToOrigin, 2pfi, (ent, pflGoal, dist, iMoveType));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_ChangeYaw(edict_t *ent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ChangeYaw(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_CHANGEYAW, pfnChangeYaw, p, (ent));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_ChangePitch(edict_t *ent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ChangePitch(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_CHANGEPITCH, pfnChangePitch, p, (ent));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN edict_t *mm_FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_FindEntityByString(edict_t *pEdictStartSearchAfter, const char *pszField, const char *pszValue) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYBYSTRING, pfnFindEntityByString, 3p, (pEdictStartSearchAfter, pszField, pszValue));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN int mm_GetEntityIllum(edict_t *pEnt) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetEntityIllum(edict_t *pEnt) {
 	META_ENGINE_HANDLE(int, 0, FN_GETENTITYILLUM, pfnGetEntityIllum, p, (pEnt));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN edict_t *mm_FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_FindEntityInSphere(edict_t *pEdictStartSearchAfter, const float *org, float rad) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYINSPHERE, pfnFindEntityInSphere, 2pf, (pEdictStartSearchAfter, org, rad));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN edict_t *mm_FindClientInPVS(edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_FindClientInPVS(edict_t *pEdict) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDCLIENTINPVS, pfnFindClientInPVS, p, (pEdict));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN edict_t *mm_EntitiesInPVS(edict_t *pplayer) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_EntitiesInPVS(edict_t *pplayer) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_ENTITIESINPVS, pfnEntitiesInPVS, p, (pplayer));
 	RETURN_API(edict_t *)
 }
 
-static FORCE_STACK_ALIGN void mm_MakeVectors(const float *rgflVector) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_MakeVectors(const float *rgflVector) {
 	META_ENGINE_HANDLE_void(FN_MAKEVECTORS, pfnMakeVectors, p, (rgflVector));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_AngleVectors(const float *rgflVector, float *forward, float *right, float *up) {
 	META_ENGINE_HANDLE_void(FN_ANGLEVECTORS, pfnAngleVectors, 4p, (rgflVector, forward, right, up));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN edict_t *mm_CreateEntity(void) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_CreateEntity(void) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATEENTITY, pfnCreateEntity, void, (VOID_ARG));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN void mm_RemoveEntity(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_RemoveEntity(edict_t *e) {
 	META_ENGINE_HANDLE_void(FN_REMOVEENTITY, pfnRemoveEntity, p, (e));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN edict_t *mm_CreateNamedEntity(int className) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_CreateNamedEntity(int className) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATENAMEDENTITY, pfnCreateNamedEntity, i, (className));
 	RETURN_API(edict_t *)
 }
 
-static FORCE_STACK_ALIGN void mm_MakeStatic(edict_t *ent) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_MakeStatic(edict_t *ent) {
 	META_ENGINE_HANDLE_void(FN_MAKESTATIC, pfnMakeStatic, p, (ent));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_EntIsOnFloor(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_EntIsOnFloor(edict_t *e) {
 	META_ENGINE_HANDLE(int, 0, FN_ENTISONFLOOR, pfnEntIsOnFloor, p, (e));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_DropToFloor(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_DropToFloor(edict_t *e) {
 	META_ENGINE_HANDLE(int, 0, FN_DROPTOFLOOR, pfnDropToFloor, p, (e));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN int mm_WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_WalkMove(edict_t *ent, float yaw, float dist, int iMode) {
 	META_ENGINE_HANDLE(int, 0, FN_WALKMOVE, pfnWalkMove, p2fi, (ent, yaw, dist, iMode));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_SetOrigin(edict_t *e, const float *rgflOrigin) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetOrigin(edict_t *e, const float *rgflOrigin) {
 	META_ENGINE_HANDLE_void(FN_SETORIGIN, pfnSetOrigin, 2p, (e, rgflOrigin));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_EmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_EmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch) {
 	META_ENGINE_HANDLE_void(FN_EMITSOUND, pfnEmitSound, pip2f2i, (entity, channel, sample, volume, attenuation, fFlags, pitch));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_EmitAmbientSound(edict_t *entity, float *pos, const char *samp, float vol, float attenuation, int fFlags, int pitch) {
 	META_ENGINE_HANDLE_void(FN_EMITAMBIENTSOUND, pfnEmitAmbientSound, 3p2f2i, (entity, pos, samp, vol, attenuation, fFlags, pitch));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACELINE, pfnTraceLine, 2pi2p, (v1, v2, fNoMonsters, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_TraceToss(edict_t *pent, edict_t *pentToIgnore, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACETOSS, pfnTraceToss, 3p, (pent, pentToIgnore, ptr));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_TraceMonsterHull(edict_t *pEdict, const float *v1, const float *v2, int fNoMonsters, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE(int, 0, FN_TRACEMONSTERHULL, pfnTraceMonsterHull, 3pi2p, (pEdict, v1, v2, fNoMonsters, pentToSkip, ptr));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_TraceHull(const float *v1, const float *v2, int fNoMonsters, int hullNumber, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACEHULL, pfnTraceHull, 2p2i2p, (v1, v2, fNoMonsters, hullNumber, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pent, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACEMODEL, pfnTraceModel, 2pi2p, (v1, v2, hullNumber, pent, ptr));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN const char *mm_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_TRACETEXTURE, pfnTraceTexture, 3p, (pTextureEntity, v1, v2));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN void mm_TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_TraceSphere(const float *v1, const float *v2, int fNoMonsters, float radius, edict_t *pentToSkip, TraceResult *ptr) {
 	META_ENGINE_HANDLE_void(FN_TRACESPHERE, pfnTraceSphere, 2pif2p, (v1, v2, fNoMonsters, radius, pentToSkip, ptr));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetAimVector(edict_t *ent, float speed, float *rgflReturn) {
 	META_ENGINE_HANDLE_void(FN_GETAIMVECTOR, pfnGetAimVector, pfp, (ent, speed, rgflReturn));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_ServerCommand(char *str) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ServerCommand(char *str) {
 	META_ENGINE_HANDLE_void(FN_SERVERCOMMAND, pfnServerCommand, p, (str));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_ServerExecute(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ServerExecute(void) {
 	META_ENGINE_HANDLE_void(FN_SERVEREXECUTE, pfnServerExecute, void, (VOID_ARG));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_engClientCommand(edict_t *pEdict, char *szFmt, ...) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_engClientCommand(edict_t *pEdict, char *szFmt, ...) {
 	META_ENGINE_HANDLE_void_varargs(FN_CLIENTCOMMAND_ENG, pfnClientCommand, 2pV, pEdict, szFmt);
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_ParticleEffect(const float *org, const float *dir, float color, float count) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ParticleEffect(const float *org, const float *dir, float color, float count) {
 	META_ENGINE_HANDLE_void(FN_PARTICLEEFFECT, pfnParticleEffect, 2p2f, (org, dir, color, count));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_LightStyle(int style, char *val) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_LightStyle(int style, char *val) {
 	META_ENGINE_HANDLE_void(FN_LIGHTSTYLE, pfnLightStyle, ip, (style, val));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_DecalIndex(const char *name) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_DecalIndex(const char *name) {
 	META_ENGINE_HANDLE(int, 0, FN_DECALINDEX, pfnDecalIndex, p, (name));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_PointContents(const float *rgflVector) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_PointContents(const float *rgflVector) {
 	META_ENGINE_HANDLE(int, 0, FN_POINTCONTENTS, pfnPointContents, p, (rgflVector));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_MessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
 	META_ENGINE_HANDLE_void(FN_MESSAGEBEGIN, pfnMessageBegin, 2i2p, (msg_dest, msg_type, pOrigin, ed));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_MessageEnd(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_MessageEnd(void) {
 	META_ENGINE_HANDLE_void(FN_MESSAGEEND, pfnMessageEnd, void, (VOID_ARG));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_WriteByte(int iValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteByte(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEBYTE, pfnWriteByte, i, (iValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteChar(int iValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteChar(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITECHAR, pfnWriteChar, i, (iValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteShort(int iValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteShort(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITESHORT, pfnWriteShort, i, (iValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteLong(int iValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteLong(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITELONG, pfnWriteLong, i, (iValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteAngle(float flValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteAngle(float flValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEANGLE, pfnWriteAngle, f, (flValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteCoord(float flValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteCoord(float flValue) {
 	META_ENGINE_HANDLE_void(FN_WRITECOORD, pfnWriteCoord, f, (flValue));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteString(const char *sz) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteString(const char *sz) {
 	META_ENGINE_HANDLE_void(FN_WRITESTRING, pfnWriteString, p, (sz));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_WriteEntity(int iValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_WriteEntity(int iValue) {
 	META_ENGINE_HANDLE_void(FN_WRITEENTITY, pfnWriteEntity, i, (iValue));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_CVarRegister(cvar_t *pCvar) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CVarRegister(cvar_t *pCvar) {
 	META_ENGINE_HANDLE_void(FN_CVARREGISTER, pfnCVarRegister, p, (pCvar));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN float mm_CVarGetFloat(const char *szVarName) {
+static HOT_FUNC FORCE_STACK_ALIGN float mm_CVarGetFloat(const char *szVarName) {
 	META_ENGINE_HANDLE(float, 0.0, FN_CVARGETFLOAT, pfnCVarGetFloat, p, (szVarName));
 	RETURN_API(float)
 }
-static FORCE_STACK_ALIGN const char *mm_CVarGetString(const char *szVarName) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_CVarGetString(const char *szVarName) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CVARGETSTRING, pfnCVarGetString, p, (szVarName));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN void mm_CVarSetFloat(const char *szVarName, float flValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CVarSetFloat(const char *szVarName, float flValue) {
 	META_ENGINE_HANDLE_void(FN_CVARSETFLOAT, pfnCVarSetFloat, pf, (szVarName, flValue));
 
 	meta_debug_value = (int)meta_debug.value;
 
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_CVarSetString(const char *szVarName, const char *szValue) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CVarSetString(const char *szVarName, const char *szValue) {
 	META_ENGINE_HANDLE_void(FN_CVARSETSTRING, pfnCVarSetString, 2p, (szVarName, szValue));
 
 	meta_debug_value = (int)meta_debug.value;
@@ -385,85 +391,78 @@ static FORCE_STACK_ALIGN void mm_CVarSetString(const char *szVarName, const char
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_AlertMessage(ALERT_TYPE atype, char *szFmt, ...) {
 	META_ENGINE_HANDLE_void_varargs(FN_ALERTMESSAGE, pfnAlertMessage, ipV, atype, szFmt);
 	RETURN_API_void()
 }
 #ifdef HLSDK_3_2_OLD_EIFACE
-static FORCE_STACK_ALIGN void mm_EngineFprintf(FILE *pfile, char *szFmt, ...) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_EngineFprintf(FILE *pfile, char *szFmt, ...) {
 #else
-static FORCE_STACK_ALIGN void mm_EngineFprintf(void *pfile, char *szFmt, ...) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_EngineFprintf(void *pfile, char *szFmt, ...) {
 #endif
 	META_ENGINE_HANDLE_void_varargs(FN_ENGINEFPRINTF, pfnEngineFprintf, 2pV, pfile, szFmt);
 	RETURN_API_void()
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, long cb) {
+static HOT_FUNC FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, long cb) {
 #else
-static FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
+static HOT_FUNC FORCE_STACK_ALIGN void *mm_PvAllocEntPrivateData(edict_t *pEdict, int32 cb) {
 #endif
 	META_ENGINE_HANDLE(void *, NULL, FN_PVALLOCENTPRIVATEDATA, pfnPvAllocEntPrivateData, pi, (pEdict, cb));
 	RETURN_API(void *)
 }
-static FORCE_STACK_ALIGN void *mm_PvEntPrivateData(edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN void *mm_PvEntPrivateData(edict_t *pEdict) {
 	META_ENGINE_HANDLE(void *, NULL, FN_PVENTPRIVATEDATA, pfnPvEntPrivateData, p, (pEdict));
 	RETURN_API(void *)
 }
-static FORCE_STACK_ALIGN void mm_FreeEntPrivateData(edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_FreeEntPrivateData(edict_t *pEdict) {
 	META_ENGINE_HANDLE_void(FN_FREEENTPRIVATEDATA, pfnFreeEntPrivateData, p, (pEdict));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN const char *mm_SzFromIndex(int iString) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_SzFromIndex(int iString) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_SZFROMINDEX, pfnSzFromIndex, i, (iString));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN int mm_AllocString(const char *szValue) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_AllocString(const char *szValue) {
 	META_ENGINE_HANDLE(int, 0, FN_ALLOCSTRING, pfnAllocString, p, (szValue));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN struct entvars_s *mm_GetVarsOfEnt(edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN struct entvars_s *mm_GetVarsOfEnt(edict_t *pEdict) {
 	META_ENGINE_HANDLE(struct entvars_s *, NULL, FN_GETVARSOFENT, pfnGetVarsOfEnt, p, (pEdict));
 	RETURN_API(struct entvars_s *)
 }
-static FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntOffset(int iEntOffset) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntOffset(int iEntOffset) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_PENTITYOFENTOFFSET, pfnPEntityOfEntOffset, i, (iEntOffset));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN int mm_EntOffsetOfPEntity(const edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_EntOffsetOfPEntity(const edict_t *pEdict) {
 	META_ENGINE_HANDLE(int, 0, FN_ENTOFFSETOFPENTITY, pfnEntOffsetOfPEntity, p, (pEdict));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_IndexOfEdict(const edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_IndexOfEdict(const edict_t *pEdict) {
 	META_ENGINE_HANDLE(int, 0, FN_INDEXOFEDICT, pfnIndexOfEdict, p, (pEdict));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntIndex(int iEntIndex) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntIndex(int iEntIndex) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_PENTITYOFENTINDEX, pfnPEntityOfEntIndex, i, (iEntIndex));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN edict_t *mm_FindEntityByVars(struct entvars_s *pvars) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_FindEntityByVars(struct entvars_s *pvars) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_FINDENTITYBYVARS, pfnFindEntityByVars, p, (pvars));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN void *mm_GetModelPtr(edict_t *pEdict) {
+static HOT_FUNC FORCE_STACK_ALIGN void *mm_GetModelPtr(edict_t *pEdict) {
 	META_ENGINE_HANDLE(void *, NULL, FN_GETMODELPTR, pfnGetModelPtr, p, (pEdict));
 	RETURN_API(void *)
 }
 
-static FORCE_STACK_ALIGN int mm_RegUserMsg(const char *pszName, int iSize) {
-	int imsgid;
-	MRegMsg *nmsg=NULL;
-	META_ENGINE_HANDLE(int, 0, FN_REGUSERMSG, pfnRegUserMsg, pi, (pszName, iSize));
-	// Expand the macro, since we need to do extra work.
-	/// RETURN_API(int)
-	imsgid = GET_RET_CLASS(ret_val, int);
-	
+static NOINLINE void metamod_RegUserMsg(const char *pszName, int iSize, int imsgid) {
 	// Add the msgid, name, and size to our saved list, if we haven't
 	// already.
-	nmsg=RegMsgs->find(imsgid);
+	MRegMsg *nmsg=RegMsgs->find(imsgid);
 	if(nmsg) {
 		if(FStrEq(pszName, nmsg->name))
 			// This name/msgid pair was already registered.
@@ -479,299 +478,306 @@ static FORCE_STACK_ALIGN int mm_RegUserMsg(const char *pszName, int iSize) {
 	}
 	else
 		RegMsgs->add(pszName, imsgid, iSize);
+}
+static HOT_FUNC FORCE_STACK_ALIGN int mm_RegUserMsg(const char *pszName, int iSize) {
+	int imsgid;
+	META_ENGINE_HANDLE(int, 0, FN_REGUSERMSG, pfnRegUserMsg, pi, (pszName, iSize));
+	// Expand the macro, since we need to do extra work.
+	/// RETURN_API(int)
+	imsgid = GET_RET_CLASS(ret_val, int);
+	metamod_RegUserMsg(pszName, iSize, imsgid);
 	return(imsgid);
 }
 
-static FORCE_STACK_ALIGN void mm_AnimationAutomove(const edict_t *pEdict, float flTime) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_AnimationAutomove(const edict_t *pEdict, float flTime) {
 	META_ENGINE_HANDLE_void(FN_ANIMATIONAUTOMOVE, pfnAnimationAutomove, pf, (pEdict, flTime));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles ) {
 	META_ENGINE_HANDLE_void(FN_GETBONEPOSITION, pfnGetBonePosition, pi2p, (pEdict, iBone, rgflOrigin, rgflAngles));
 	RETURN_API_void()
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static FORCE_STACK_ALIGN unsigned long mm_FunctionFromName( const char *pName ) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned long mm_FunctionFromName( const char *pName ) {
 	META_ENGINE_HANDLE(unsigned long, 0, FN_FUNCTIONFROMNAME, pfnFunctionFromName, p, (pName));
 	RETURN_API(unsigned long)
 }
 #else
-static FORCE_STACK_ALIGN uint32 mm_FunctionFromName( const char *pName ) {
+static HOT_FUNC FORCE_STACK_ALIGN uint32 mm_FunctionFromName( const char *pName ) {
 	META_ENGINE_HANDLE(uint32, 0, FN_FUNCTIONFROMNAME, pfnFunctionFromName, p, (pName));
 	RETURN_API(uint32)
 }
 #endif
 #ifdef HLSDK_3_2_OLD_EIFACE
-static FORCE_STACK_ALIGN const char *mm_NameForFunction( unsigned long function ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_NameForFunction( unsigned long function ) {
 #else
-static FORCE_STACK_ALIGN const char *mm_NameForFunction( uint32 function ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_NameForFunction( uint32 function ) {
 #endif
 	META_ENGINE_HANDLE(const char *, NULL, FN_NAMEFORFUNCTION, pfnNameForFunction, ui, (function));
 	RETURN_API(const char *)
 }
 
 //! JOHN: engine callbacks so game DLL can print messages to individual clients
-static FORCE_STACK_ALIGN void mm_ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ClientPrintf( edict_t *pEdict, PRINT_TYPE ptype, const char *szMsg ) {
 	META_ENGINE_HANDLE_void(FN_CLIENTPRINTF, pfnClientPrintf, pip, (pEdict, ptype, szMsg));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_ServerPrint( const char *szMsg ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ServerPrint( const char *szMsg ) {
 	META_ENGINE_HANDLE_void(FN_SERVERPRINT, pfnServerPrint, p, (szMsg));
 	RETURN_API_void()
 }
 
 //! these 3 added so game DLL can easily access client 'cmd' strings
-static FORCE_STACK_ALIGN const char *mm_Cmd_Args( void ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_Cmd_Args( void ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CMD_ARGS, pfnCmd_Args, void, (VOID_ARG));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN const char *mm_Cmd_Argv( int argc ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_Cmd_Argv( int argc ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_CMD_ARGV, pfnCmd_Argv, i, (argc));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN int mm_Cmd_Argc( void ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_Cmd_Argc( void ) {
 	META_ENGINE_HANDLE(int, 0, FN_CMD_ARGC, pfnCmd_Argc, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles ) {
 	META_ENGINE_HANDLE_void(FN_GETATTACHMENT, pfnGetAttachment, pi2p, (pEdict, iAttachment, rgflOrigin, rgflAngles));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_CRC32_Init(CRC32_t *pulCRC) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CRC32_Init(CRC32_t *pulCRC) {
 	META_ENGINE_HANDLE_void(FN_CRC32_INIT, pfnCRC32_Init, p, (pulCRC));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CRC32_ProcessBuffer(CRC32_t *pulCRC, void *p, int len) {
 	META_ENGINE_HANDLE_void(FN_CRC32_PROCESSBUFFER, pfnCRC32_ProcessBuffer, 2pi, (pulCRC, p, len));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
 	META_ENGINE_HANDLE_void(FN_CRC32_PROCESSBYTE, pfnCRC32_ProcessByte, puc, (pulCRC, ch));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN CRC32_t mm_CRC32_Final(CRC32_t pulCRC) {
+static HOT_FUNC FORCE_STACK_ALIGN CRC32_t mm_CRC32_Final(CRC32_t pulCRC) {
 	META_ENGINE_HANDLE(CRC32_t, 0, FN_CRC32_FINAL, pfnCRC32_Final, ul, (pulCRC));
 	RETURN_API(CRC32_t)
 }
 
 #ifdef HLSDK_3_2_OLD_EIFACE
-static FORCE_STACK_ALIGN long mm_RandomLong(long lLow, long lHigh) {
+static HOT_FUNC FORCE_STACK_ALIGN long mm_RandomLong(long lLow, long lHigh) {
 	META_ENGINE_HANDLE(long, 0, FN_RANDOMLONG, pfnRandomLong, 2i, (lLow, lHigh));
 	RETURN_API(long)
 }
 #else
-static FORCE_STACK_ALIGN int32 mm_RandomLong(int32 lLow, int32 lHigh) {
+static HOT_FUNC FORCE_STACK_ALIGN int32 mm_RandomLong(int32 lLow, int32 lHigh) {
 	META_ENGINE_HANDLE(int32, 0, FN_RANDOMLONG, pfnRandomLong, 2i, (lLow, lHigh));
 	RETURN_API(int32)
 }
 #endif
-static FORCE_STACK_ALIGN float mm_RandomFloat(float flLow, float flHigh) {
+static HOT_FUNC FORCE_STACK_ALIGN float mm_RandomFloat(float flLow, float flHigh) {
 	META_ENGINE_HANDLE(float, 0.0, FN_RANDOMFLOAT, pfnRandomFloat, 2f, (flLow, flHigh));
 	RETURN_API(float)
 }
 
-static FORCE_STACK_ALIGN void mm_SetView(const edict_t *pClient, const edict_t *pViewent ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetView(const edict_t *pClient, const edict_t *pViewent ) {
 	META_ENGINE_HANDLE_void(FN_SETVIEW, pfnSetView, 2p, (pClient, pViewent));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN float mm_Time( void ) {
+static HOT_FUNC FORCE_STACK_ALIGN float mm_Time( void ) {
 	META_ENGINE_HANDLE(float, 0.0, FN_TIME, pfnTime, void, (VOID_ARG));
 	RETURN_API(float)
 }
-static FORCE_STACK_ALIGN void mm_CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_CrosshairAngle(const edict_t *pClient, float pitch, float yaw) {
 	META_ENGINE_HANDLE_void(FN_CROSSHAIRANGLE, pfnCrosshairAngle, p2f, (pClient, pitch, yaw));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN byte * mm_LoadFileForMe(char *filename, int *pLength) {
+static HOT_FUNC FORCE_STACK_ALIGN byte * mm_LoadFileForMe(char *filename, int *pLength) {
 	META_ENGINE_HANDLE(byte *, NULL, FN_LOADFILEFORME, pfnLoadFileForMe, 2p, (filename, pLength));
 	RETURN_API(byte *)
 }
-static FORCE_STACK_ALIGN void mm_FreeFile(void *buffer) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_FreeFile(void *buffer) {
 	META_ENGINE_HANDLE_void(FN_FREEFILE, pfnFreeFile, p, (buffer));
 	RETURN_API_void()
 }
 
 //! trigger_endsection
-static FORCE_STACK_ALIGN void mm_EndSection(const char *pszSectionName) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_EndSection(const char *pszSectionName) {
 	META_ENGINE_HANDLE_void(FN_ENDSECTION, pfnEndSection, p, (pszSectionName));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_CompareFileTime(char *filename1, char *filename2, int *iCompare) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_CompareFileTime(char *filename1, char *filename2, int *iCompare) {
 	META_ENGINE_HANDLE(int, 0, FN_COMPAREFILETIME, pfnCompareFileTime, 3p, (filename1, filename2, iCompare));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_GetGameDir(char *szGetGameDir) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetGameDir(char *szGetGameDir) {
 	META_ENGINE_HANDLE_void(FN_GETGAMEDIR, pfnGetGameDir, p, (szGetGameDir));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_Cvar_RegisterVariable(cvar_t *variable) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_Cvar_RegisterVariable(cvar_t *variable) {
 	META_ENGINE_HANDLE_void(FN_CVAR_REGISTERVARIABLE, pfnCvar_RegisterVariable, p, (variable));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_FadeClientVolume(const edict_t *pEdict, int fadePercent, int fadeOutSeconds, int holdTime, int fadeInSeconds) {
 	META_ENGINE_HANDLE_void(FN_FADECLIENTVOLUME, pfnFadeClientVolume, p4i, (pEdict, fadePercent, fadeOutSeconds, holdTime, fadeInSeconds));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed) {
 	META_ENGINE_HANDLE_void(FN_SETCLIENTMAXSPEED, pfnSetClientMaxspeed, pf, (pEdict, fNewMaxspeed));
 	RETURN_API_void()
 }
 //! returns NULL if fake client can't be created
-static FORCE_STACK_ALIGN edict_t * mm_CreateFakeClient(const char *netname) {
+static HOT_FUNC FORCE_STACK_ALIGN edict_t * mm_CreateFakeClient(const char *netname) {
 	META_ENGINE_HANDLE(edict_t *, NULL, FN_CREATEFAKECLIENT, pfnCreateFakeClient, p, (netname));
 	RETURN_API(edict_t *)
 }
-static FORCE_STACK_ALIGN void mm_RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
 	META_ENGINE_HANDLE_void(FN_RUNPLAYERMOVE, pfnRunPlayerMove, 2p3fus2uc, (fakeclient, viewangles, forwardmove, sidemove, upmove, buttons, impulse, msec));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_NumberOfEntities(void) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_NumberOfEntities(void) {
 	META_ENGINE_HANDLE(int, 0, FN_NUMBEROFENTITIES, pfnNumberOfEntities, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
 //! passing in NULL gets the serverinfo
-static FORCE_STACK_ALIGN char *mm_GetInfoKeyBuffer(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN char *mm_GetInfoKeyBuffer(edict_t *e) {
 	META_ENGINE_HANDLE(char *, NULL, FN_GETINFOKEYBUFFER, pfnGetInfoKeyBuffer, p, (e));
 	RETURN_API(char *)
 }
-static FORCE_STACK_ALIGN char *mm_InfoKeyValue(char *infobuffer, char *key) {
+static HOT_FUNC FORCE_STACK_ALIGN char *mm_InfoKeyValue(char *infobuffer, char *key) {
 	META_ENGINE_HANDLE(char *, NULL, FN_INFOKEYVALUE, pfnInfoKeyValue, 2p, (infobuffer, key));
 	RETURN_API(char *)
 }
-static FORCE_STACK_ALIGN void mm_SetKeyValue(char *infobuffer, char *key, char *value) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetKeyValue(char *infobuffer, char *key, char *value) {
 	META_ENGINE_HANDLE_void(FN_SETKEYVALUE, pfnSetKeyValue, 3p, (infobuffer, key, value));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetClientKeyValue(int clientIndex, char *infobuffer, char *key, char *value) {
 	META_ENGINE_HANDLE_void(FN_SETCLIENTKEYVALUE, pfnSetClientKeyValue, i3p, (clientIndex, infobuffer, key, value));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN int mm_IsMapValid(char *filename) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_IsMapValid(char *filename) {
 	META_ENGINE_HANDLE(int, 0, FN_ISMAPVALID, pfnIsMapValid, p, (filename));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_StaticDecal( const float *origin, int decalIndex, int entityIndex, int modelIndex ) {
 	META_ENGINE_HANDLE_void(FN_STATICDECAL, pfnStaticDecal, p3i, (origin, decalIndex, entityIndex, modelIndex));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_PrecacheGeneric(char *s) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_PrecacheGeneric(char *s) {
 	META_ENGINE_HANDLE(int, 0, FN_PRECACHEGENERIC, pfnPrecacheGeneric, p, (s));
 	RETURN_API(int)
 }
 //! returns the server assigned userid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-static FORCE_STACK_ALIGN int mm_GetPlayerUserId(edict_t *e ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetPlayerUserId(edict_t *e ) {
 	META_ENGINE_HANDLE(int, 0, FN_GETPLAYERUSERID, pfnGetPlayerUserId, p, (e));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_BuildSoundMsg(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch, int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) 
-{
+static HOT_FUNC FORCE_STACK_ALIGN void mm_BuildSoundMsg(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch, int msg_dest, int msg_type, const float *pOrigin, edict_t *ed) {
 	META_ENGINE_HANDLE_void(FN_BUILDSOUNDMSG, pfnBuildSoundMsg, pip2f4i2p, (entity, channel, sample, volume, attenuation, fFlags, pitch, msg_dest, msg_type, pOrigin, ed));
 	RETURN_API_void()
 }
 //! is this a dedicated server?
-static FORCE_STACK_ALIGN int mm_IsDedicatedServer(void) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_IsDedicatedServer(void) {
 	META_ENGINE_HANDLE(int, 0, FN_ISDEDICATEDSERVER, pfnIsDedicatedServer, void, (VOID_ARG));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN cvar_t *mm_CVarGetPointer(const char *szVarName) {
+static HOT_FUNC FORCE_STACK_ALIGN cvar_t *mm_CVarGetPointer(const char *szVarName) {
 	META_ENGINE_HANDLE(cvar_t *, NULL, FN_CVARGETPOINTER, pfnCVarGetPointer, p, (szVarName));
 	RETURN_API(cvar_t *)
 }
 //! returns the server assigned WONid for this player. useful for logging frags, etc. returns -1 if the edict couldn't be found in the list of clients
-static FORCE_STACK_ALIGN unsigned int mm_GetPlayerWONId(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned int mm_GetPlayerWONId(edict_t *e) {
 	META_ENGINE_HANDLE(unsigned int, 0, FN_GETPLAYERWONID, pfnGetPlayerWONId, p, (e));
 	RETURN_API(unsigned int)
 }
 
 //! YWB 8/1/99 TFF Physics additions
-static FORCE_STACK_ALIGN void mm_Info_RemoveKey( char *s, const char *key ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_Info_RemoveKey( char *s, const char *key ) {
 	META_ENGINE_HANDLE_void(FN_INFO_REMOVEKEY, pfnInfo_RemoveKey, 2p, (s, key));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN const char *mm_GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_GetPhysicsKeyValue( const edict_t *pClient, const char *key ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPHYSICSKEYVALUE, pfnGetPhysicsKeyValue, 2p, (pClient, key));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN void mm_SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetPhysicsKeyValue( const edict_t *pClient, const char *key, const char *value ) {
 	META_ENGINE_HANDLE_void(FN_SETPHYSICSKEYVALUE, pfnSetPhysicsKeyValue, 3p, (pClient, key, value));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN const char *mm_GetPhysicsInfoString( const edict_t *pClient ) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_GetPhysicsInfoString( const edict_t *pClient ) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPHYSICSINFOSTRING, pfnGetPhysicsInfoString, p, (pClient));
 	RETURN_API(const char *)
 }
-static FORCE_STACK_ALIGN unsigned short mm_PrecacheEvent( int type, const char *psz ) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned short mm_PrecacheEvent( int type, const char *psz ) {
 	META_ENGINE_HANDLE(unsigned short, 0, FN_PRECACHEEVENT, pfnPrecacheEvent, ip, (type, psz));
 	RETURN_API(unsigned short)
 }
-static FORCE_STACK_ALIGN void mm_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 ) {
 	META_ENGINE_HANDLE_void(FN_PLAYBACKEVENT, pfnPlaybackEvent, ipusf2p2f4i, (flags, pInvoker, eventindex, delay, origin, angles, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN unsigned char *mm_SetFatPVS( float *org ) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned char *mm_SetFatPVS( float *org ) {
 	META_ENGINE_HANDLE(unsigned char *, 0, FN_SETFATPVS, pfnSetFatPVS, p, (org));
 	RETURN_API(unsigned char *)
 }
-static FORCE_STACK_ALIGN unsigned char *mm_SetFatPAS( float *org ) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned char *mm_SetFatPAS( float *org ) {
 	META_ENGINE_HANDLE(unsigned char *, 0, FN_SETFATPAS, pfnSetFatPAS, p, (org));
 	RETURN_API(unsigned char *)
 }
 
-static FORCE_STACK_ALIGN int mm_CheckVisibility( const edict_t *entity, unsigned char *pset ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_CheckVisibility( const edict_t *entity, unsigned char *pset ) {
 	META_ENGINE_HANDLE(int, 0, FN_CHECKVISIBILITY, pfnCheckVisibility, 2p, (entity, pset));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DeltaSetField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE_void(FN_DELTASETFIELD, pfnDeltaSetField, 2p, (pFields, fieldname));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DeltaUnsetField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE_void(FN_DELTAUNSETFIELD, pfnDeltaUnsetField, 2p, (pFields, fieldname));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DeltaAddEncoder( char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) ) {
 	META_ENGINE_HANDLE_void(FN_DELTAADDENCODER, pfnDeltaAddEncoder, 2p, (name, (void*)conditionalencode));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN int mm_GetCurrentPlayer( void ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetCurrentPlayer( void ) {
 	META_ENGINE_HANDLE(int, 0, FN_GETCURRENTPLAYER, pfnGetCurrentPlayer, void, (VOID_ARG));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_CanSkipPlayer( const edict_t *player ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_CanSkipPlayer( const edict_t *player ) {
 	META_ENGINE_HANDLE(int, 0, FN_CANSKIPPLAYER, pfnCanSkipPlayer, p, (player));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN int mm_DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_DeltaFindField( struct delta_s *pFields, const char *fieldname ) {
 	META_ENGINE_HANDLE(int, 0, FN_DELTAFINDFIELD, pfnDeltaFindField, 2p, (pFields, fieldname));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DeltaSetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	META_ENGINE_HANDLE_void(FN_DELTASETFIELDBYINDEX, pfnDeltaSetFieldByIndex, pi, (pFields, fieldNumber));
 	RETURN_API_void()
 }
-static FORCE_STACK_ALIGN void mm_DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_DeltaUnsetFieldByIndex( struct delta_s *pFields, int fieldNumber ) {
 	META_ENGINE_HANDLE_void(FN_DELTAUNSETFIELDBYINDEX, pfnDeltaUnsetFieldByIndex, pi, (pFields, fieldNumber));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_SetGroupMask( int mask, int op ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_SetGroupMask( int mask, int op ) {
 	META_ENGINE_HANDLE_void(FN_SETGROUPMASK, pfnSetGroupMask, 2i, (mask, op));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN int mm_engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_engCreateInstancedBaseline( int classname, struct entity_state_s *baseline ) {
 	META_ENGINE_HANDLE(int, 0, FN_CREATEINSTANCEDBASELINE, pfnCreateInstancedBaseline, ip, (classname, baseline));
 	RETURN_API(int)
 }
-static FORCE_STACK_ALIGN void mm_Cvar_DirectSet( struct cvar_s *var, char *value ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_Cvar_DirectSet( struct cvar_s *var, char *value ) {
 	META_ENGINE_HANDLE_void(FN_CVAR_DIRECTSET, pfnCvar_DirectSet, 2p, (var, value));
 
 	meta_debug_value = (int)meta_debug.value;
@@ -782,17 +788,17 @@ static FORCE_STACK_ALIGN void mm_Cvar_DirectSet( struct cvar_s *var, char *value
 //! Forces the client and server to be running with the same version of the specified file
 //!( e.g., a player model ).
 //! Calling this has no effect in single player
-static FORCE_STACK_ALIGN void mm_ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ForceUnmodified( FORCE_TYPE type, float *mins, float *maxs, const char *filename ) {
 	META_ENGINE_HANDLE_void(FN_FORCEUNMODIFIED, pfnForceUnmodified, i3p, (type, mins, maxs, filename));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_GetPlayerStats( const edict_t *pClient, int *ping, int *packet_loss ) {
 	META_ENGINE_HANDLE_void(FN_GETPLAYERSTATS, pfnGetPlayerStats, 3p, (pClient, ping, packet_loss));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_AddServerCommand( char *cmd_name, void (*function) (void) ) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_AddServerCommand( char *cmd_name, void (*function) (void) ) {
 	META_ENGINE_HANDLE_void(FN_ADDSERVERCOMMAND, pfnAddServerCommand, 2p, (cmd_name, (void*)function));
 	RETURN_API_void()
 }
@@ -801,88 +807,93 @@ static FORCE_STACK_ALIGN void mm_AddServerCommand( char *cmd_name, void (*functi
 
 //! For voice communications, set which clients hear eachother.
 //! NOTE: these functions take player entity indices (starting at 1).
-static FORCE_STACK_ALIGN qboolean mm_Voice_GetClientListening(int iReceiver, int iSender) {
+static HOT_FUNC FORCE_STACK_ALIGN qboolean mm_Voice_GetClientListening(int iReceiver, int iSender) {
 	META_ENGINE_HANDLE(qboolean, false, FN_VOICE_GETCLIENTLISTENING, pfnVoice_GetClientListening, 2i, (iReceiver, iSender));
 	RETURN_API(qboolean)
 }
-static FORCE_STACK_ALIGN qboolean mm_Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
+static HOT_FUNC FORCE_STACK_ALIGN qboolean mm_Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen) {
 	META_ENGINE_HANDLE(qboolean, false, FN_VOICE_SETCLIENTLISTENING, pfnVoice_SetClientListening, 3i, (iReceiver, iSender, bListen));
 	RETURN_API(qboolean)
 }
 
 // Added for HL 1109 (no SDK update):
 
-static FORCE_STACK_ALIGN const char *mm_GetPlayerAuthId(edict_t *e) {
+static HOT_FUNC FORCE_STACK_ALIGN const char *mm_GetPlayerAuthId(edict_t *e) {
 	META_ENGINE_HANDLE(const char *, NULL, FN_GETPLAYERAUTHID, pfnGetPlayerAuthId, p, (e));
 	RETURN_API(const char *)
 }
 
 // Added 2003/11/10 (no SDK update):
 
-static FORCE_STACK_ALIGN sequenceEntry_s *mm_SequenceGet(const char *fileName, const char *entryName) {
+static HOT_FUNC FORCE_STACK_ALIGN sequenceEntry_s *mm_SequenceGet(const char *fileName, const char *entryName) {
 	META_ENGINE_HANDLE(sequenceEntry_s *, NULL, FN_SEQUENCEGET, pfnSequenceGet, 2p, (fileName, entryName));
 	RETURN_API(sequenceEntry_s *)
 }
 
-static FORCE_STACK_ALIGN sentenceEntry_s *mm_SequencePickSentence(const char *groupName, int pickMethod, int *picked) {
+static HOT_FUNC FORCE_STACK_ALIGN sentenceEntry_s *mm_SequencePickSentence(const char *groupName, int pickMethod, int *picked) {
 	META_ENGINE_HANDLE(sentenceEntry_s *, NULL, FN_SEQUENCEPICKSENTENCE, pfnSequencePickSentence, pip, (groupName, pickMethod, picked));
 	RETURN_API(sentenceEntry_s *)
 }
 
-static FORCE_STACK_ALIGN int mm_GetFileSize(char *filename) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetFileSize(char *filename) {
 	META_ENGINE_HANDLE(int, 0, FN_GETFILESIZE, pfnGetFileSize, p, (filename));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN unsigned int mm_GetApproxWavePlayLen(const char *filepath) {
+static HOT_FUNC FORCE_STACK_ALIGN unsigned int mm_GetApproxWavePlayLen(const char *filepath) {
 	META_ENGINE_HANDLE(unsigned int, 0, FN_GETAPPROXWAVEPLAYLEN, pfnGetApproxWavePlayLen, p, (filepath));
 	RETURN_API(unsigned int)
 }
 
-static FORCE_STACK_ALIGN int mm_IsCareerMatch(void) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_IsCareerMatch(void) {
 	META_ENGINE_HANDLE(int, 0, FN_ISCAREERMATCH, pfnIsCareerMatch, void, (VOID_ARG));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN int mm_GetLocalizedStringLength(const char *label) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetLocalizedStringLength(const char *label) {
 	META_ENGINE_HANDLE(int, 0, FN_GETLOCALIZEDSTRINGLENGTH, pfnGetLocalizedStringLength, p, (label));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_RegisterTutorMessageShown(int mid) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_RegisterTutorMessageShown(int mid) {
 	META_ENGINE_HANDLE_void(FN_REGISTERTUTORMESSAGESHOWN, pfnRegisterTutorMessageShown, i, (mid));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN int mm_GetTimesTutorMessageShown(int mid) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_GetTimesTutorMessageShown(int mid) {
 	META_ENGINE_HANDLE(int, 0, FN_GETTIMESTUTORMESSAGESHOWN, pfnGetTimesTutorMessageShown, i, (mid));
 	RETURN_API(int)
 }
 
-static FORCE_STACK_ALIGN void mm_ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ProcessTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	META_ENGINE_HANDLE_void(FN_PROCESSTUTORMESSAGEDECAYBUFFER, pfnProcessTutorMessageDecayBuffer, pi, (buffer, bufferLength));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ConstructTutorMessageDecayBuffer(int *buffer, int bufferLength) {
 	META_ENGINE_HANDLE_void(FN_CONSTRUCTTUTORMESSAGEDECAYBUFFER, pfnConstructTutorMessageDecayBuffer, pi, (buffer, bufferLength));
 	RETURN_API_void()
 }
 
-static FORCE_STACK_ALIGN void mm_ResetTutorMessageDecayData(void) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_ResetTutorMessageDecayData(void) {
 	META_ENGINE_HANDLE_void(FN_RESETTUTORMESSAGEDECAYDATA, pfnResetTutorMessageDecayData, void, (VOID_ARG));
 	RETURN_API_void()
 }
 
+static NOINLINE void check_engine_pointer_validity(mBOOL *check, void **ptr) {
+	if (!IS_VALID_PTR(*ptr)) {
+		*ptr = NULL;
+		*check = mTRUE;
+	}
+}
+
 // Added 2005/08/11 (no SDK update):
-static FORCE_STACK_ALIGN void mm_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_QueryClientCvarValue(const edict_t *player, const char *cvarName) {
 	static mBOOL s_check = mFALSE;
 	
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.
-	if (!s_check && g_engfuncs.pfnQueryClientCvarValue &&
-	     !IS_VALID_PTR((void * )g_engfuncs.pfnQueryClientCvarValue)) {
-		g_engfuncs.pfnQueryClientCvarValue = NULL;
-		s_check = mTRUE;
+	if (!s_check && g_engfuncs.pfnQueryClientCvarValue) {
+	     check_engine_pointer_validity(&s_check, (void **)&g_engfuncs.pfnQueryClientCvarValue);
 	}
 	
 	META_ENGINE_HANDLE_void(FN_QUERYCLIENTCVARVALUE, pfnQueryClientCvarValue, 2p, (player, cvarName));
@@ -890,14 +901,12 @@ static FORCE_STACK_ALIGN void mm_QueryClientCvarValue(const edict_t *player, con
 }
 
 // Added 2005/11/21 (no SDK update):
-static FORCE_STACK_ALIGN void mm_QueryClientCvarValue2(const edict_t *player, const char *cvarName, int requestID) {
+static HOT_FUNC FORCE_STACK_ALIGN void mm_QueryClientCvarValue2(const edict_t *player, const char *cvarName, int requestID) {
 	static mBOOL s_check = mFALSE;
 	
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.
-	if (!s_check && g_engfuncs.pfnQueryClientCvarValue2 &&
-	     !IS_VALID_PTR((void * )g_engfuncs.pfnQueryClientCvarValue2)) {
-		g_engfuncs.pfnQueryClientCvarValue2 = NULL;
-		s_check = mTRUE;
+	if (!s_check && g_engfuncs.pfnQueryClientCvarValue2) {
+	     check_engine_pointer_validity(&s_check, (void **)&g_engfuncs.pfnQueryClientCvarValue2);
 	}
 	
 	META_ENGINE_HANDLE_void(FN_QUERYCLIENTCVARVALUE2, pfnQueryClientCvarValue2, 2pi, (player, cvarName, requestID));
@@ -905,14 +914,12 @@ static FORCE_STACK_ALIGN void mm_QueryClientCvarValue2(const edict_t *player, co
 }
 
 // Added 2009/06/19 (no SDK update):
-static FORCE_STACK_ALIGN int mm_EngCheckParm(const char *pchCmdLineToken, char **pchNextVal) {
+static HOT_FUNC FORCE_STACK_ALIGN int mm_EngCheckParm(const char *pchCmdLineToken, char **pchNextVal) {
 	static mBOOL s_check = mFALSE;
 
 	//Engine version didn't change when this API was added.  Check if the pointer is valid.
-	if (!s_check && g_engfuncs.pfnEngCheckParm &&
-	     !IS_VALID_PTR((void * )g_engfuncs.pfnEngCheckParm)) {
-		g_engfuncs.pfnEngCheckParm = NULL;
-		s_check = mTRUE;
+	if (!s_check && g_engfuncs.pfnEngCheckParm) {
+	     check_engine_pointer_validity(&s_check, (void **)&g_engfuncs.pfnEngCheckParm);
 	}
 
 	META_ENGINE_HANDLE(int, 0, FN_ENGCHECKPARM, pfnEngCheckParm, 2p, (pchCmdLineToken, pchNextVal));

--- a/metamod/engine_t.h
+++ b/metamod/engine_t.h
@@ -42,33 +42,34 @@
 #include "comp_dep.h"
 #include "osdep.h"	//unlikely, OPEN_ARGS
 
+// Engine function table pointer (hot path, extracted for cache locality).
+extern enginefuncs_t *Engine_funcs DLLHIDDEN;
+
 // Our structure for storing engine references.
 struct engine_t {
 	engine_t() DLLINTERNAL;
 	engine_t(const engine_t&) DLLINTERNAL;
 	engine_t& operator=(const engine_t&) DLLINTERNAL;
 
-	enginefuncs_t	*funcs;			// engine funcs
 	globalvars_t	*globals;		// engine globals
 	enginefuncs_t	*pl_funcs;		// "modified" eng funcs we give to plugins
 	EngineInfo       info;          // some special info elements
 };
 
-inline engine_t::engine_t() 
-    : funcs(NULL), globals(NULL), pl_funcs(NULL), info() 
+inline engine_t::engine_t()
+    : globals(NULL), pl_funcs(NULL), info()
 {
 }
 
 
-inline engine_t::engine_t(const engine_t& _rhs) 
-    : funcs(_rhs.funcs), globals(_rhs.globals), pl_funcs(_rhs.pl_funcs), info(_rhs.info) 
+inline engine_t::engine_t(const engine_t& _rhs)
+    : globals(_rhs.globals), pl_funcs(_rhs.pl_funcs), info(_rhs.info)
 {
 }
 
 
-inline engine_t& engine_t::operator=(const engine_t& _rhs) 
+inline engine_t& engine_t::operator=(const engine_t& _rhs)
 {
-    funcs = _rhs.funcs;
     globals = _rhs.globals;
     pl_funcs = _rhs.pl_funcs;
     info = _rhs.info;

--- a/metamod/h_export.cpp
+++ b/metamod/h_export.cpp
@@ -76,6 +76,7 @@ void _fini(void) {
 //! Holds engine functionality callbacks
 HL_enginefuncs_t g_engfuncs;
 globalvars_t  *gpGlobals;
+HOT_DATA enginefuncs_t *Engine_funcs;
 engine_t Engine;
 
 // Receive engine function table from engine.
@@ -90,7 +91,7 @@ C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfun
 	metamod_handle = get_module_handle_of_memptr((void*)&g_engfuncs);
 #endif /* __linux__ */
 	gpGlobals = pGlobals;
-	Engine.funcs = &g_engfuncs;
+	Engine_funcs = &g_engfuncs;
 	Engine.globals = pGlobals;
 	Engine.info.initialise(pengfuncsFromEngine);
 

--- a/metamod/hotdata.ld
+++ b/metamod/hotdata.ld
@@ -1,0 +1,13 @@
+/* Align hot-path data sections to cache line boundary */
+SECTIONS
+{
+  .data.hot_data : ALIGN(64)
+  {
+    *(.data.hot_data)
+  }
+  .data.hot_rodata : ALIGN(4)
+  {
+    *(.data.hot_rodata)
+  }
+}
+INSERT AFTER .data;

--- a/metamod/i386pe.merge
+++ b/metamod/i386pe.merge
@@ -48,6 +48,9 @@ SECTIONS
     *(.data)
     *(.data2)
     *(SORT(.data$*))
+    . = ALIGN(64);
+    *(.data.hot_data)
+    *(.data.hot_rodata)
     __data_end__ = . ;
     *(.data_cygwin_nocopy)
     *(.eh_frame)

--- a/metamod/log_meta.cpp
+++ b/metamod/log_meta.cpp
@@ -47,7 +47,7 @@
 
 cvar_t meta_debug = {"meta_debug", "0", FCVAR_EXTDLL, 0, NULL};
 
-int meta_debug_value = 0; //meta_debug_value is converted from float(meta_debug.value) to int on every frame
+HOT_DATA int meta_debug_value = 0; //meta_debug_value is converted from float(meta_debug.value) to int on every frame
 
 enum MLOG_SERVICE {
 	mlsCONS = 1,

--- a/metamod/metamod.cpp
+++ b/metamod/metamod.cpp
@@ -71,14 +71,15 @@ option_t global_options[] = {
 	{ NULL, CF_NONE, NULL, NULL }
 };
 
+HOT_DATA gamedll_funcs_t GameDLL_funcs;
 gamedll_t GameDLL;
 
-meta_globals_t PublicMetaGlobals;
+HOT_DATA meta_globals_t PublicMetaGlobals;
 meta_globals_t PrivateMetaGlobals;
 
 meta_enginefuncs_t g_plugin_engfuncs;
 
-MPluginList *Plugins;
+HOT_DATA MPluginList *Plugins;
 MRegCmdList *RegCmds;
 MRegCvarList *RegCvars;
 MRegMsgList *RegMsgs;
@@ -207,7 +208,7 @@ int DLLINTERNAL metamod_startup(void) {
 	// Copy, and store pointer in Engine struct.  Yes, we could just store
 	// the actual engine_t struct in Engine, but then it wouldn't be a
 	// pointer to match the other g_engfuncs.
-	g_plugin_engfuncs.set_from(Engine.funcs);
+	g_plugin_engfuncs.set_from(Engine_funcs);
 	Engine.pl_funcs=&g_plugin_engfuncs;
 	// substitute our special versions of various commands
 	Engine.pl_funcs->pfnAddServerCommand = meta_AddServerCommand;
@@ -393,18 +394,18 @@ mBOOL DLLINTERNAL meta_load_gamedll(void) {
 	// Yes...another macro.
 #define GET_FUNC_TABLE_FROM_GAME(gamedll, pfnGetFuncs, STR_GetFuncs, struct_field, API_TYPE, TABLE_TYPE, vers_pass, vers_int, vers_want, gotit) \
 		if((pfnGetFuncs = (API_TYPE) DLSYM(gamedll.handle, STR_GetFuncs))) { \
-			gamedll.funcs.struct_field = (TABLE_TYPE*) calloc(1, sizeof(TABLE_TYPE)); \
-			if(!gamedll.funcs.struct_field) {\
+			GameDLL_funcs.struct_field = (TABLE_TYPE*) calloc(1, sizeof(TABLE_TYPE)); \
+			if(!GameDLL_funcs.struct_field) {\
 				META_WARNING("malloc failed for gamedll struct_field: %s", STR_GetFuncs); \
 			} \
-			else if(pfnGetFuncs(gamedll.funcs.struct_field, vers_pass)) { \
+			else if(pfnGetFuncs(GameDLL_funcs.struct_field, vers_pass)) { \
 				META_DEBUG(3, ("dll: Game '%s': Found %s", gamedll.name, STR_GetFuncs)); \
 				gotit=1; \
 			} \
 			else { \
 				META_WARNING("dll: Failure calling %s in game '%s'", STR_GetFuncs, gamedll.name); \
-				free(gamedll.funcs.struct_field); \
-				gamedll.funcs.struct_field=NULL; \
+				free(GameDLL_funcs.struct_field); \
+				GameDLL_funcs.struct_field=NULL; \
 				if(vers_int != vers_want) { \
 					META_WARNING("dll: Interface version didn't match; we wanted %d, they had %d", vers_want, vers_int); \
 					/* reproduce error from engine */ \
@@ -422,7 +423,7 @@ mBOOL DLLINTERNAL meta_load_gamedll(void) {
 		} \
 		else { \
 			META_DEBUG(5, ("dll: Game '%s': No %s", gamedll.name, STR_GetFuncs)); \
-			gamedll.funcs.struct_field=NULL; \
+			GameDLL_funcs.struct_field=NULL; \
 		}
 
 	// Look for API-NEW interface in Game dll.  We do this before API2/API, because
@@ -453,7 +454,7 @@ mBOOL DLLINTERNAL meta_load_gamedll(void) {
 		RETURN_ERRNO(mFALSE, ME_DLMISSING);
 	}
 
-	if(!GameDLL.funcs.dllapi_table) {
+	if(!GameDLL_funcs.dllapi_table) {
 		META_WARNING("dll: GetEntityAPI function pointer is null in game DLL '%s'", GameDLL.name);
 		RETURN_ERRNO(mFALSE, ME_DLMISSING);
 	}

--- a/metamod/metamod.h
+++ b/metamod/metamod.h
@@ -70,14 +70,14 @@ extern cvar_t meta_version DLLHIDDEN;
 
 // Info about the game dll/mod.
 typedef struct gamedll_s {
+	gamedll_funcs_t funcs;		// dllapi_table, newapi_table
+	char const *file;		// ie "cs_i386.so"
+	const char *desc;		// ie "Counter-Strike"
+	DLHANDLE handle;
 	char name[NAME_MAX];		// ie "cstrike" (from gamedir)
-	const char *desc;				// ie "Counter-Strike"
 	char gamedir[PATH_MAX];		// ie "/home/willday/half-life/cstrike"
 	char pathname[PATH_MAX];	// ie "/home/willday/half-life/cstrike/dlls/cs_i386.so"
-	char const *file;			// ie "cs_i386.so"
 	char real_pathname[PATH_MAX];	// in case pathname overridden by bot, etc
-	DLHANDLE handle;
-	gamedll_funcs_t funcs;		// dllapi_table, newapi_table
 } gamedll_t;
 extern gamedll_t GameDLL DLLHIDDEN;
 

--- a/metamod/metamod.h
+++ b/metamod/metamod.h
@@ -68,9 +68,11 @@ extern DLHANDLE metamod_handle DLLHIDDEN;
 // cvar to contain version
 extern cvar_t meta_version DLLHIDDEN;
 
+// Game DLL function tables (hot path, extracted for cache locality).
+extern gamedll_funcs_t GameDLL_funcs DLLHIDDEN;
+
 // Info about the game dll/mod.
 typedef struct gamedll_s {
-	gamedll_funcs_t funcs;		// dllapi_table, newapi_table
 	char const *file;		// ie "cs_i386.so"
 	const char *desc;		// ie "Counter-Strike"
 	DLHANDLE handle;

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -60,12 +60,12 @@ struct api_plugin_list_t {
 class MPluginList : public class_metamod_new {
 	public:
 	// data:
-		MPlugin plist[MAX_PLUGINS];			// array of plugins
+		api_plugin_list_t hook_lists[3][2];		// pre-filtered per-api [pre,post] plugin arrays
+		MPlugin **hook_list_data;			// backing allocation for hook_lists plugs pointers
 		int size;					// size of list, ie MAX_PLUGINS
 		int endlist;					// index of last used entry
+		MPlugin plist[MAX_PLUGINS];			// array of plugins
 		char inifile[PATH_MAX];				// full pathname
-		api_plugin_list_t hook_lists[3][2];
-		MPlugin **hook_list_data;
 
 		inline DLLINTERNAL const api_plugin_list_t * get_hook_list(enum_api_t api) {
 			return(&hook_lists[api][0]);

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -835,8 +835,8 @@ mBOOL DLLINTERNAL MPlugin::attach(PLUG_LOADTIME now) {
 			META_WARNING("dll: Failed attach plugin '%s': Failed malloc() for dllapi_table");
 			RETURN_ERRNO(mFALSE, ME_NOMEM);
 		}
-		if(GameDLL.funcs.dllapi_table)
-			memcpy(gamedll_funcs.dllapi_table, GameDLL.funcs.dllapi_table, sizeof(DLL_FUNCTIONS));
+		if(GameDLL_funcs.dllapi_table)
+			memcpy(gamedll_funcs.dllapi_table, GameDLL_funcs.dllapi_table, sizeof(DLL_FUNCTIONS));
 		else
 			memset(gamedll_funcs.dllapi_table, 0, sizeof(DLL_FUNCTIONS));
 	}
@@ -846,8 +846,8 @@ mBOOL DLLINTERNAL MPlugin::attach(PLUG_LOADTIME now) {
 			META_WARNING("dll: Failed attach plugin '%s': Failed malloc() for newapi_table");
 			RETURN_ERRNO(mFALSE, ME_NOMEM);
 		}
-		if(GameDLL.funcs.newapi_table)
-			memcpy(gamedll_funcs.newapi_table, GameDLL.funcs.newapi_table, sizeof(NEW_DLL_FUNCTIONS));
+		if(GameDLL_funcs.newapi_table)
+			memcpy(gamedll_funcs.newapi_table, GameDLL_funcs.newapi_table, sizeof(NEW_DLL_FUNCTIONS));
 		else
 			memset(gamedll_funcs.newapi_table, 0, sizeof(NEW_DLL_FUNCTIONS));
 	}

--- a/metamod/mplugin.h
+++ b/metamod/mplugin.h
@@ -127,8 +127,8 @@ class MPlugin : public class_metamod_new {
 			PLUG_STATUS status;			// current status of plugin (loaded, etc)
 			int status_int;				// int alias for switch without enum-load UB
 		};
-		api_tables_t tables;
-		api_tables_t post_tables;
+		api_tables_t tables;				// plugin's API function tables
+		api_tables_t post_tables;			// plugin's post-API function tables
 
 		inline DLLINTERNAL void * get_api_table(enum_api_t api) {
 			return(((void**)&tables)[api]);
@@ -137,6 +137,7 @@ class MPlugin : public class_metamod_new {
 			return(((void**)&post_tables)[api]);
 		}
 
+		char *file;					// ie "mm_test_i386.so", ptr from filename
 		int index;					// 1-based
 		int pfspecific;                  		// level of specific platform affinity, used during load time
 		union {
@@ -150,16 +151,15 @@ class MPlugin : public class_metamod_new {
 		int source_plugin_index;			// index of plugin that loaded this plugin. -1 means source plugin has been unloaded.
 		int unloader_index;
 		mBOOL is_unloader;				// fix to prevent other plugins unload active unloader.
-		
+
 		DLHANDLE handle;				// handle for dlopen, dlsym, etc
 		plugin_info_t *info;				// information plugin provides about itself
 		time_t time_loaded;				// when plugin was loaded
 		
-		char filename[PATH_MAX];			// ie "dlls/mm_test_i386.so", from inifile
-		char *file;					// ie "mm_test_i386.so", ptr from filename
 		char desc[MAX_DESC_LEN];			// ie "Test metamod plugin", from inifile
+		char filename[PATH_MAX];			// ie "dlls/mm_test_i386.so", from inifile
 		char pathname[PATH_MAX];			// UNIQUE, ie "/home/willday/half-life/cstrike/dlls/mm_test_i386.so", built with GameDLL.gamedir
-		
+
 	// functions:		
 		mBOOL DLLINTERNAL ini_parseline(const char *line);		// parse line from inifile
 		mBOOL DLLINTERNAL cmd_parseline(const char *line);		// parse from console command

--- a/metamod/tests/engine_mock.cpp
+++ b/metamod/tests/engine_mock.cpp
@@ -37,6 +37,7 @@ __attribute__((weak)) globalvars_t *gpGlobals = &mock_globalvars;
 
 __attribute__((weak)) HL_enginefuncs_t g_engfuncs;
 __attribute__((weak)) engine_t Engine;
+__attribute__((weak)) enginefuncs_t *Engine_funcs = NULL;
 __attribute__((weak)) meta_enginefuncs_t g_plugin_engfuncs;
 
 // ============================================================
@@ -414,7 +415,7 @@ void mock_reset(void)
 	mock_gamedir[0] = '\0';
 	mock_localinfo_count = 0;
 
-	Engine.funcs = (enginefuncs_t *)&g_engfuncs;
+	Engine_funcs = (enginefuncs_t *)&g_engfuncs;
 	Engine.globals = gpGlobals;
 
 	memset(&GameDLL, 0, sizeof(GameDLL));

--- a/metamod/tests/stubs.cpp
+++ b/metamod/tests/stubs.cpp
@@ -16,7 +16,9 @@
 extern __attribute__((weak)) const dllapi_info_t dllapi_info = {};
 extern __attribute__((weak)) const newapi_info_t newapi_info = {};
 extern __attribute__((weak)) const engine_info_t engine_info = {};
+__attribute__((weak)) gamedll_funcs_t GameDLL_funcs = {};
 __attribute__((weak)) mutil_funcs_t MetaUtilFunctions = {};
+__attribute__((weak)) enginefuncs_t *Engine_funcs = NULL;
 __attribute__((weak)) meta_enginefuncs_t meta_engfuncs;
 
 __attribute__((weak)) void main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *) {}

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -181,7 +181,7 @@ static void setup_one_plugin(void)
 	memset(&gamedll_funcs, 0, sizeof(gamedll_funcs));
 	gamedll_funcs.pfnGameInit = mock_gamedll_init;
 	gamedll_funcs.pfnSpawn = mock_gamedll_spawn;
-	GameDLL.funcs.dllapi_table = &gamedll_funcs;
+	GameDLL_funcs.dllapi_table = &gamedll_funcs;
 
 	memset(&plugin1_pre_funcs, 0, sizeof(plugin1_pre_funcs));
 	memset(&plugin1_post_funcs, 0, sizeof(plugin1_post_funcs));
@@ -226,7 +226,7 @@ static void teardown(void)
 	RegCvars = NULL;
 	RegMsgs = NULL;
 	Config = NULL;
-	GameDLL.funcs.dllapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
 }
 
 // Helper: call GameDLLInit through the hook dispatcher
@@ -703,7 +703,7 @@ static int test_return_null_gamedll_table(void)
 {
 	TEST("dispatch return - NULL game DLL table handled");
 	setup_one_plugin();
-	GameDLL.funcs.dllapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
 	call_hooked_Spawn();
 	ASSERT_TRUE(g_gamedll_called == 0);
 	teardown();
@@ -731,7 +731,7 @@ static int test_null_gamedll_table(void)
 {
 	TEST("dispatch void - NULL game DLL table handled gracefully");
 	setup_one_plugin();
-	GameDLL.funcs.dllapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
 
 	call_hooked_GameInit();
 	ASSERT_TRUE(g_gamedll_called == 0);

--- a/metamod/tests/test_dllapi.cpp
+++ b/metamod/tests/test_dllapi.cpp
@@ -60,7 +60,7 @@ static void setup_globals(void)
 	mock_dll_funcs.pfnThink = mock_think;
 	mock_dll_funcs.pfnServerDeactivate = mock_server_deactivate;
 	mock_dll_funcs.pfnStartFrame = mock_start_frame;
-	GameDLL.funcs.dllapi_table = &mock_dll_funcs;
+	GameDLL_funcs.dllapi_table = &mock_dll_funcs;
 
 	g_game_init_called = 0;
 	g_spawn_called = 0;
@@ -76,7 +76,7 @@ static void teardown_globals(void)
 	RegCvars = NULL;
 	RegMsgs = NULL;
 	Config = NULL;
-	GameDLL.funcs.dllapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
 }
 
 // ============================================================
@@ -307,7 +307,7 @@ static int test_hook_null_game_table(void)
 {
 	TEST("hook - NULL game DLL table handled gracefully");
 	setup_globals();
-	GameDLL.funcs.dllapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
 	DLL_FUNCTIONS funcs;
 	memset(&funcs, 0, sizeof(funcs));
 	int ver = INTERFACE_VERSION;
@@ -492,7 +492,7 @@ static int test_hook_new_dll_functions(void)
 	mock_new_funcs.pfnShouldCollide = stub_should_collide;
 	mock_new_funcs.pfnCvarValue = stub_cvar_value;
 	mock_new_funcs.pfnCvarValue2 = stub_cvar_value2;
-	GameDLL.funcs.newapi_table = &mock_new_funcs;
+	GameDLL_funcs.newapi_table = &mock_new_funcs;
 
 	NEW_DLL_FUNCTIONS funcs;
 	memset(&funcs, 0, sizeof(funcs));
@@ -510,7 +510,7 @@ static int test_hook_new_dll_functions(void)
 	funcs.pfnCvarValue(&ed, "val"); ASSERT_INT(g_call_count, 4);
 	funcs.pfnCvarValue2(&ed, 1, "cv", "val"); ASSERT_INT(g_call_count, 5);
 
-	GameDLL.funcs.newapi_table = NULL;
+	GameDLL_funcs.newapi_table = NULL;
 	teardown_globals();
 	PASS();
 	return 0;
@@ -523,7 +523,7 @@ static int test_hook_client_command_meta(void)
 	test_config.clientmeta = 1;
 
 	mock_dll_funcs.pfnClientCommand = stub_void_p;
-	GameDLL.funcs.dllapi_table = &mock_dll_funcs;
+	GameDLL_funcs.dllapi_table = &mock_dll_funcs;
 
 	DLL_FUNCTIONS funcs;
 	memset(&funcs, 0, sizeof(funcs));

--- a/metamod/tests/test_engine_api.cpp
+++ b/metamod/tests/test_engine_api.cpp
@@ -66,7 +66,7 @@ static void setup_globals(void)
 	mock_eng_table.pfnPrecacheModel = mock_eng_precache_model;
 	mock_eng_table.pfnPrecacheSound = mock_eng_precache_sound;
 	mock_eng_table.pfnServerPrint = mock_eng_server_print;
-	Engine.funcs = &mock_eng_table;
+	Engine_funcs = &mock_eng_table;
 
 	g_precache_model_called = 0;
 	g_precache_sound_called = 0;
@@ -135,7 +135,7 @@ static int test_hook_null_engine_table(void)
 {
 	TEST("engine hook - NULL engine table handled gracefully");
 	setup_globals();
-	Engine.funcs = NULL;
+	Engine_funcs = NULL;
 	meta_engfuncs.pfnServerPrint("test");
 	ASSERT_TRUE(g_server_print_called == 0);
 	teardown_globals();

--- a/metamod/tests/test_h_export.cpp
+++ b/metamod/tests/test_h_export.cpp
@@ -76,7 +76,7 @@ static int test_give_sets_engine_globals(void)
 
 static int test_give_sets_engine_funcs(void)
 {
-	TEST("GiveFnptrsToDll - sets Engine.funcs to g_engfuncs");
+	TEST("GiveFnptrsToDll - sets Engine_funcs to g_engfuncs");
 	mock_reset();
 	g_metamod_startup_retval = 1;
 	metamod_not_loaded = 0;
@@ -88,7 +88,7 @@ static int test_give_sets_engine_funcs(void)
 
 	GiveFnptrsToDll(&test_engfuncs, &test_globals);
 
-	ASSERT_TRUE(Engine.funcs == (enginefuncs_t *)&g_engfuncs);
+	ASSERT_TRUE(Engine_funcs == (enginefuncs_t *)&g_engfuncs);
 	PASS();
 	return 0;
 }

--- a/metamod/tests/test_metamod_gamedll.cpp
+++ b/metamod/tests/test_metamod_gamedll.cpp
@@ -213,13 +213,13 @@ static void cleanup_startup_allocs(void)
 		if (Config->test_get_filename()) { free(Config->test_get_filename()); Config->test_set_filename(NULL); }
 	}
 	Config = &static_config;
-	if (GameDLL.funcs.dllapi_table) {
-		free(GameDLL.funcs.dllapi_table);
-		GameDLL.funcs.dllapi_table = NULL;
+	if (GameDLL_funcs.dllapi_table) {
+		free(GameDLL_funcs.dllapi_table);
+		GameDLL_funcs.dllapi_table = NULL;
 	}
-	if (GameDLL.funcs.newapi_table) {
-		free(GameDLL.funcs.newapi_table);
-		GameDLL.funcs.newapi_table = NULL;
+	if (GameDLL_funcs.newapi_table) {
+		free(GameDLL_funcs.newapi_table);
+		GameDLL_funcs.newapi_table = NULL;
 	}
 }
 
@@ -250,8 +250,8 @@ static int test_load_gamedll_success(void)
 	ASSERT_TRUE(g_getentityapi2_called);
 	ASSERT_TRUE(g_getnewdllfunctions_called);
 	ASSERT_TRUE(GameDLL.handle == (DLHANDLE)FAKE_GAMEDLL_HANDLE);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.dllapi_table);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.newapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.dllapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.newapi_table);
 	cleanup_startup_allocs();
 
 	PASS();
@@ -328,7 +328,7 @@ static int test_load_gamedll_api1_fallback(void)
 	ASSERT_TRUE(ret == mTRUE);
 	ASSERT_FALSE(g_getentityapi2_called);
 	ASSERT_TRUE(g_getentityapi_called);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.dllapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.dllapi_table);
 	cleanup_startup_allocs();
 
 	PASS();
@@ -376,8 +376,8 @@ static int test_load_gamedll_no_newdll(void)
 
 	mBOOL ret = meta_load_gamedll();
 	ASSERT_TRUE(ret == mTRUE);
-	ASSERT_PTR_NULL(GameDLL.funcs.newapi_table);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.dllapi_table);
+	ASSERT_PTR_NULL(GameDLL_funcs.newapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.dllapi_table);
 	cleanup_startup_allocs();
 
 	PASS();
@@ -392,8 +392,8 @@ static int test_load_gamedll_newdll_returns_false(void)
 
 	mBOOL ret = meta_load_gamedll();
 	ASSERT_TRUE(ret == mTRUE);
-	ASSERT_PTR_NULL(GameDLL.funcs.newapi_table);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.dllapi_table);
+	ASSERT_PTR_NULL(GameDLL_funcs.newapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.dllapi_table);
 	cleanup_startup_allocs();
 
 	PASS();
@@ -434,7 +434,7 @@ static int test_startup_full_success(void)
 	ASSERT_TRUE(ret == 1);
 	ASSERT_TRUE(g_givefnptrstodll_called);
 	ASSERT_TRUE(g_getentityapi2_called);
-	ASSERT_PTR_NOT_NULL(GameDLL.funcs.dllapi_table);
+	ASSERT_PTR_NOT_NULL(GameDLL_funcs.dllapi_table);
 	cleanup_startup_allocs();
 
 	PASS();

--- a/metamod/tests/test_mplugin_lifecycle.cpp
+++ b/metamod/tests/test_mplugin_lifecycle.cpp
@@ -583,8 +583,8 @@ static int test_load_with_gamedll_tables(void)
 	NEW_DLL_FUNCTIONS gdll_newapi;
 	memset(&gdll_funcs, 0, sizeof(gdll_funcs));
 	memset(&gdll_newapi, 0, sizeof(gdll_newapi));
-	GameDLL.funcs.dllapi_table = &gdll_funcs;
-	GameDLL.funcs.newapi_table = &gdll_newapi;
+	GameDLL_funcs.dllapi_table = &gdll_funcs;
+	GameDLL_funcs.newapi_table = &gdll_newapi;
 	MPlugin plug;
 	setup_plugin_for_load(&plug, "dlls/copytbl.so");
 	mBOOL ret = plug.load(PT_ANYTIME);
@@ -593,8 +593,8 @@ static int test_load_with_gamedll_tables(void)
 	ASSERT_PTR_NOT_NULL(plug.test_gamedll_funcs().dllapi_table);
 	ASSERT_PTR_NOT_NULL(plug.test_gamedll_funcs().newapi_table);
 	plug.free_api_pointers();
-	GameDLL.funcs.dllapi_table = NULL;
-	GameDLL.funcs.newapi_table = NULL;
+	GameDLL_funcs.dllapi_table = NULL;
+	GameDLL_funcs.newapi_table = NULL;
 	teardown_globals();
 	PASS();
 	return 0;


### PR DESCRIPTION
## Summary

- Fix win32 cross-compilation: pass `OS=windows` for win32 targets, use `-flto=auto`, deduplicate install paths
- Make `api_tables` and `api_info_tables` fully const for better compiler optimization
- Reorder struct fields in `gamedll_t`, `MPluginList`, and `MPlugin` to improve cache locality by placing hot-path fields first
- Remove unused `trace` field from `api_info_t`, shrinking info tables
- Add `HOT_FUNC` attribute (`hot` + `no_stack_protector`) to all dispatch path functions, reducing stack canary sites from 262 to 47
- Extract `GameDLL.funcs` and `Engine.funcs` into standalone globals (`GameDLL_funcs`, `Engine_funcs`) for cache locality
- Add `HOT_DATA`/`HOT_RODATA` section attributes and linker scripts to colocate hot-path globals (`GameDLL_funcs`, `Engine_funcs`, `PublicMetaGlobals`, `Plugins`, `meta_debug_value`, `api_tables`, `api_info_tables`) into a single 64-byte cache-aligned section
- Binary size reduced from 257988 to 254224 bytes (-1.5%)

## META_PERFMON benchmark (RDTSC cycles per hook dispatch)

Measured on 11th Gen Intel i5-1135G7, HLDS with 19 bots, 3x300s runs.
Benchmarked before the cache-line colocate commit (last 2 bullets above).

| | Run 1 | Run 2 | Run 3 | Mean |
|---|---|---|---|---|
| master | 180.4 | 181.3 | 181.6 | **181.1** |
| PR | 178.4 | 176.7 | 183.3 | **179.5** |

**Delta: -1.6 cycles/hook (-0.9%)**

## Test plan
- [x] Linux opt builds clean (no warnings/errors)
- [x] Win32 opt builds clean (no warnings/errors)
- [x] All 804 unit tests pass
- [x] Verified via objdump that stack canaries removed from dispatch functions
- [x] Verified via nm/map that hot-path data fits in single 64-byte cache line