### PR TITLE
Fix clean target to remove subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ clean cleanall:
 	for i in $(SUBDIRS); do \
 		$(MAKE) -C $$i cleanall || exit; \
 	done
-	-rm dlls/* dlls/debug/*
+	-rm -fr dlls/* dlls/debug/*


### PR DESCRIPTION
## Summary
- Use `rm -fr` instead of `rm` in the clean target so subdirectories under `dlls/` are removed properly

## Test plan
- [x] `make cleanall` completes without errors