### PR TITLE
Pass version from release tag to binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: 'Version tag (e.g. v1.21p99) to embed in binary'
 
 jobs:
   build-linux:
@@ -11,10 +16,16 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install packages
         run: sudo apt-get -y update && sudo apt-get -y install build-essential gcc-i686-linux-gnu g++-i686-linux-gnu
+      - name: Parse patch version
+        id: ver
+        if: inputs.version
+        run: |
+          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
       - name: Build metamod (debug)
-        run: make -j4 -C metamod CC="i686-linux-gnu-gcc"
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
       - name: Build metamod (optimized)
-        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC="i686-linux-gnu-gcc" OPT=opt
       - name: Build stub_plugin (optimized)
@@ -36,12 +47,18 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - name: Parse patch version
+        id: ver
+        if: inputs.version
+        run: |
+          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
       - name: Build in Ubuntu 18.04 i386 container
         run: |
           docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
             lpenz/ubuntu-bionic-i386 \
             bash -c "apt-get -y update && apt-get -y install build-essential g++ make && \
-              make -j4 -C metamod OPT=opt && \
+              make -j4 -C metamod OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }} && \
               make -j4 -C trace_plugin OPT=opt && \
               make -j4 -C stub_plugin OPT=opt && \
               make -j4 -C wdmisc_plugin OPT=opt"
@@ -62,8 +79,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install packages
         run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
+      - name: Parse patch version
+        id: ver
+        if: inputs.version
+        run: |
+          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
       - name: Build metamod (optimized)
-        run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+        run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32 ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
       - name: Build stub_plugin (optimized)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
   build:
     needs: validate-tag
     uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.version }}
 
   package:
     needs: [validate-tag, build]

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -180,6 +180,11 @@ CFLAGS=-Wall -Wno-unknown-pragmas -Wno-attributes -Wno-write-strings -Wno-class-
 
 CFLAGS+=-std=gnu++98 -Wno-c++11-compat
 
+# Override version from command line: make META_VERSION=99
+ifdef META_VERSION
+CFLAGS += -DVPATCH_IVERSION=$(META_VERSION) -DVPATCH_VERSION="\"$(META_VERSION)\""
+endif
+
 #CFLAGS += -DTEST
 
 ifeq "$(OPT)" "opt-fast"

--- a/metamod/vers_meta.h
+++ b/metamod/vers_meta.h
@@ -48,8 +48,12 @@
 #define VMETA_VERSION		"1.21"
 
 #define VPATCH_NAME		"Metamod-P (mm-p)"
+#ifndef VPATCH_IVERSION
 #define VPATCH_IVERSION		38
+#endif
+#ifndef VPATCH_VERSION
 #define VPATCH_VERSION		"38"
+#endif
 #define VPATCH_AUTHOR		"Jussi Kivilinna"
 #define VPATCH_WEBSITE		"http://metamod-p.sourceforge.net/"
 


### PR DESCRIPTION
## Summary
- The release workflow parsed the tag version but only used it for naming archive files — the binary still reported hardcoded `1.21p38` from `vers_meta.h`
- Add `META_VERSION` make variable that overrides `VPATCH_IVERSION`/`VPATCH_VERSION` via `-D` compiler flags
- Wire release.yml → build.yml: pass version input, extract patch number from tag, pass to make

## Test plan
- [x] Local build with `make META_VERSION=99` produces binary reporting `1.21p99`
- [x] Build without `META_VERSION` still uses header defaults (CI snapshot builds unaffected)
- [ ] Push a test tag to verify the full release pipeline embeds the correct version