### PR TITLE
Pass release date to binary via META_DATE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,20 @@ jobs:
       - name: Parse patch version
         id: ver
         if: inputs.version
+        env:
+          VERSION_TAG: ${{ inputs.version }}
         run: |
-          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          PATCH=$(echo "$VERSION_TAG" | sed -n 's/^v[0-9]*\.[0-9]*p0*\([0-9]\+\)$/\1/p')
+          if [ -z "$PATCH" ]; then
+            echo "::error::Failed to parse patch version from '$VERSION_TAG'"
+            exit 1
+          fi
           echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y/%m/%d)" >> "$GITHUB_OUTPUT"
       - name: Build metamod (debug)
-        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" ${{ steps.ver.outputs.patch && format('META_VERSION={0} META_DATE={1}', steps.ver.outputs.patch, steps.ver.outputs.date) || '' }}
       - name: Build metamod (optimized)
-        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
+        run: make -j4 -C metamod CC="i686-linux-gnu-gcc" OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0} META_DATE={1}', steps.ver.outputs.patch, steps.ver.outputs.date) || '' }}
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC="i686-linux-gnu-gcc" OPT=opt
       - name: Build stub_plugin (optimized)
@@ -50,15 +57,22 @@ jobs:
       - name: Parse patch version
         id: ver
         if: inputs.version
+        env:
+          VERSION_TAG: ${{ inputs.version }}
         run: |
-          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          PATCH=$(echo "$VERSION_TAG" | sed -n 's/^v[0-9]*\.[0-9]*p0*\([0-9]\+\)$/\1/p')
+          if [ -z "$PATCH" ]; then
+            echo "::error::Failed to parse patch version from '$VERSION_TAG'"
+            exit 1
+          fi
           echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y/%m/%d)" >> "$GITHUB_OUTPUT"
       - name: Build in Ubuntu 18.04 i386 container
         run: |
           docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
             lpenz/ubuntu-bionic-i386 \
             bash -c "apt-get -y update && apt-get -y install build-essential g++ make && \
-              make -j4 -C metamod OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }} && \
+              make -j4 -C metamod OPT=opt ${{ steps.ver.outputs.patch && format('META_VERSION={0} META_DATE={1}', steps.ver.outputs.patch, steps.ver.outputs.date) || '' }} && \
               make -j4 -C trace_plugin OPT=opt && \
               make -j4 -C stub_plugin OPT=opt && \
               make -j4 -C wdmisc_plugin OPT=opt"
@@ -82,11 +96,18 @@ jobs:
       - name: Parse patch version
         id: ver
         if: inputs.version
+        env:
+          VERSION_TAG: ${{ inputs.version }}
         run: |
-          PATCH=$(echo "${{ inputs.version }}" | sed -n 's/^v[0-9]*\.[0-9]*p\([0-9]*\)$/\1/p')
+          PATCH=$(echo "$VERSION_TAG" | sed -n 's/^v[0-9]*\.[0-9]*p0*\([0-9]\+\)$/\1/p')
+          if [ -z "$PATCH" ]; then
+            echo "::error::Failed to parse patch version from '$VERSION_TAG'"
+            exit 1
+          fi
           echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y/%m/%d)" >> "$GITHUB_OUTPUT"
       - name: Build metamod (optimized)
-        run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32 ${{ steps.ver.outputs.patch && format('META_VERSION={0}', steps.ver.outputs.patch) || '' }}
+        run: make -j4 -C metamod CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32 ${{ steps.ver.outputs.patch && format('META_VERSION={0} META_DATE={1}', steps.ver.outputs.patch, steps.ver.outputs.date) || '' }}
       - name: Build trace_plugin (optimized)
         run: make -j4 -C trace_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
       - name: Build stub_plugin (optimized)

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -180,10 +180,17 @@ CFLAGS=-Wall -Wno-unknown-pragmas -Wno-attributes -Wno-write-strings -Wno-class-
 
 CFLAGS+=-std=gnu++98 -Wno-c++11-compat
 
-# Override version from command line: make META_VERSION=99
+# Override version from command line: make META_VERSION=99 META_DATE=2026/05/16
 ifdef META_VERSION
-CFLAGS += -DVPATCH_IVERSION=$(META_VERSION) -DVPATCH_VERSION="\"$(META_VERSION)\""
+META_DEFS += -DVPATCH_IVERSION=$(META_VERSION) -DVPATCH_VERSION="\"$(META_VERSION)\""
+META_DEFS_RES += '-DVPATCH_IVERSION=$(META_VERSION)' '-DVPATCH_VERSION="\"$(META_VERSION)\""'
 endif
+ifdef META_DATE
+META_COPYRIGHT_YEAR := $(firstword $(subst /, ,$(META_DATE)))
+META_DEFS += -DVDATE="\"$(META_DATE)\"" -DVPATCH_COPYRIGHT_YEAR="\"$(META_COPYRIGHT_YEAR)\""
+META_DEFS_RES += '-DVDATE="\"$(META_DATE)\""' '-DVPATCH_COPYRIGHT_YEAR="\"$(META_COPYRIGHT_YEAR)\""'
+endif
+CFLAGS += $(META_DEFS)
 
 #CFLAGS += -DTEST
 
@@ -264,7 +271,7 @@ TARGET_LINUX = $(OBJDIR_LINUX)/$(LIBFILE_LINUX)
 
 # windows .dll compile commands
 DO_CC_WIN=$(CC_WIN) $(CFLAGS) $(INCLUDEDIRS) -o $@ -c $<
-DO_RES_WIN=$(RES_WIN) '$(ODEF)' --include-dir . --include-dir ../metamod -i $< -O coff -o $@
+DO_RES_WIN=$(RES_WIN) '$(ODEF)' $(META_DEFS_RES) --include-dir . --include-dir ../metamod -i $< -O coff -o $@
 LINK_WIN=$(CC_WIN) $(CFLAGS) -mdll -Xlinker --add-stdcall-alias $(EXTRA_LINK) $(OBJ_WIN) $(RES_OBJ_WIN) -s -o $@
 
 # windows object files

--- a/metamod/vers_meta.h
+++ b/metamod/vers_meta.h
@@ -43,8 +43,12 @@
 #endif /* not OPT_TYPE */
 
 
+#ifndef VDATE
 #define VDATE 			"2018/02/11"
+#endif
+#ifndef VPATCH_COPYRIGHT_YEAR
 #define VPATCH_COPYRIGHT_YEAR   "2018"
+#endif
 #define VMETA_VERSION		"1.21"
 
 #define VPATCH_NAME		"Metamod-P (mm-p)"


### PR DESCRIPTION
## Summary
- `VDATE` and `VPATCH_COPYRIGHT_YEAR` were hardcoded to `2018` in `vers_meta.h`, causing the binary to display `2018/02/11` even for new releases
- Make both overridable via `#ifndef` guards
- Add `META_DATE` make variable (e.g. `make META_DATE=2026/05/16`) that passes `-DVDATE` and auto-extracts the copyright year
- Build workflow sets `META_DATE` to current date during release builds

## Test plan
- [x] Local build with `META_VERSION=99 META_DATE=2026/05/16` shows correct date and version in binary
- [x] Build without META_DATE still uses header defaults
- [ ] Retag release to verify full pipeline