### PR TITLE
Add missing pfnPEntityOfEntIndexAllEntities to enginefuncs_t

### DIFF
--- a/hlsdk/engine/eiface.h
+++ b/hlsdk/engine/eiface.h
@@ -314,6 +314,9 @@ typedef struct enginefuncs_s
 	// Added 2009/06/19 (no SDK update):
 	int 		(*pfnEngCheckParm)			(const char *pchCmdLineToken, char **pchNextVal);
 
+	// Added 2024/08/21 (HL25 SDK update):
+	edict_t*	(*pfnPEntityOfEntIndexAllEntities)	(int iEntIndex);
+
 #ifdef __METAMOD_BUILD__
 	//extra (future updates)
 	void * extra_functions[16];

--- a/metamod/api_info.cpp
+++ b/metamod/api_info.cpp
@@ -270,6 +270,8 @@ const engine_info_t engine_info = {
 	{3,	api_caller_void_args_2pi,	"QueryClientCvarValue2" },	// pfnQueryClientCvarValue2
 	// Added 2009-06-17 (no SDK update):
 	{8,	api_caller_int_args_2p,		"EngCheckParm" },		// pfnEngCheckParm
+	// Added 2024/08/21 (HL25 SDK update):
+	{26,	api_caller_ptr_args_i,		"PEntityOfEntIndexAllEntities" },	// pfnPEntityOfEntIndexAllEntities
 	// end
 	{0,   NULL,	NULL },
 };

--- a/metamod/api_info.h
+++ b/metamod/api_info.h
@@ -299,6 +299,8 @@ typedef struct engine_info_s {
 	api_info_t pfnQueryClientCvarValue2;
 	// Added 2009/06/17 (no SDK update):
 	api_info_t pfnEngCheckParm;
+	// Added 2024/08/21 (HL25 SDK update):
+	api_info_t pfnPEntityOfEntIndexAllEntities;
 	// end
 	api_info_t END;
 } engine_info_t;

--- a/metamod/engine_api.cpp
+++ b/metamod/engine_api.cpp
@@ -926,6 +926,18 @@ static HOT_FUNC FORCE_STACK_ALIGN int mm_EngCheckParm(const char *pchCmdLineToke
 	RETURN_API(int)
 }
 
+// Added 2024/08/21 (HL25 SDK update):
+static HOT_FUNC FORCE_STACK_ALIGN edict_t *mm_PEntityOfEntIndexAllEntities(int iEntIndex) {
+	static mBOOL s_check = mFALSE;
+
+	if (!s_check && g_engfuncs.pfnPEntityOfEntIndexAllEntities) {
+	     check_engine_pointer_validity(&s_check, (void **)&g_engfuncs.pfnPEntityOfEntIndexAllEntities);
+	}
+
+	META_ENGINE_HANDLE(edict_t *, NULL, FN_PENTITYOFENTINDEXALLENTITIES, pfnPEntityOfEntIndexAllEntities, i, (iEntIndex));
+	RETURN_API(edict_t *)
+}
+
 meta_enginefuncs_t meta_engfuncs (
 	&mm_PrecacheModel,			// pfnPrecacheModel()
 	&mm_PrecacheSound,			// pfnPrecacheSound()
@@ -1137,5 +1149,8 @@ meta_enginefuncs_t meta_engfuncs (
 	&mm_QueryClientCvarValue2,		// pfnQueryClientCvarValue2()
 
 	// Added 2009/06/17 (no SDK update):
-	&mm_EngCheckParm			// pfnEngCheckParm()
+	&mm_EngCheckParm,			// pfnEngCheckParm()
+
+	// Added 2024/08/21 (HL25 SDK update):
+	&mm_PEntityOfEntIndexAllEntities	// pfnPEntityOfEntIndexAllEntities()
 );

--- a/metamod/engine_api.h
+++ b/metamod/engine_api.h
@@ -236,5 +236,7 @@ typedef void (*FN_QUERYCLIENTCVARVALUE) ( const edict_t *player, const char *cva
 typedef void (*FN_QUERYCLIENTCVARVALUE2) ( const edict_t *player, const char *cvarName, int requestID );
 // Added 2009/06/17 (no SDK update):
 typedef void (*FN_ENGCHECKPARM) ( const char *pchCmdLineToken, char **pchNextVal );
+// Added 2024/08/21 (HL25 SDK update):
+typedef edict_t * (*FN_PENTITYOFENTINDEXALLENTITIES) (int iEntIndex);
 
 #endif /* ENGINE_API_H */

--- a/metamod/meta_eiface.cpp
+++ b/metamod/meta_eiface.cpp
@@ -329,7 +329,8 @@ meta_enginefuncs_t::meta_enginefuncs_t(
 	void             (*_pfnResetTutorMessageDecayData)      (void),
 	void             (*_pfnQueryClientCvarValue)            (const edict_t*, const char*),
 	void             (*_pfnQueryClientCvarValue2)           (const edict_t*, const char*, int),
-	int             (*_pfnEngCheckParm)           		(const char*, char**)
+	int             (*_pfnEngCheckParm)           		(const char*, char**),
+	edict_t*        (*_pfnPEntityOfEntIndexAllEntities)	(int)
     )
 {
 	pfnPrecacheModel = _pfnPrecacheModel;
@@ -490,6 +491,7 @@ meta_enginefuncs_t::meta_enginefuncs_t(
 	pfnQueryClientCvarValue = _pfnQueryClientCvarValue;
 	pfnQueryClientCvarValue2 = _pfnQueryClientCvarValue2;
 	pfnEngCheckParm = _pfnEngCheckParm;
+	pfnPEntityOfEntIndexAllEntities = _pfnPEntityOfEntIndexAllEntities;
 
 	memset( extra_functions, 0, sizeof(extra_functions));
 
@@ -553,6 +555,7 @@ void HL_enginefuncs_t::initialise_interface( enginefuncs_t *_pFuncs )
 // 156:	void		(*pfnQueryClientCvarValue)		( const edict_t *player, const char *cvarName );
 // 157:	void		(*pfnQueryClientCvarValue2)             ( const edict_t *player, const char *cvarName, int requestID );
 // 158: int		(*pfnEngCheckParm)			( const char *pchCmdLineToke, char **pchNextValue );
+// 159: edict_t*	(*pfnPEntityOfEntIndexAllEntities)	( int iEntIndex );	// Added 2024/08/21 (HL25 SDK update)
 
 void HL_enginefuncs_t::determine_engine_interface_version( void )
 {
@@ -683,6 +686,14 @@ void HL_enginefuncs_t::determine_engine_interface_version( void )
 		return;
 	}
 	sm_version = 158;
+
+	// All functions up to PEntityOfEntIndexAllEntities() are valid.
+	// If PEntityOfEntIndexAllEntities() is not valid, leave it at the
+	// so far determined version. Otherwise the version is at least 159.
+	if ( pfnPEntityOfEntIndexAllEntities == NULL) {
+		return;
+	}
+	sm_version = 159;
 }
 
 
@@ -718,6 +729,8 @@ void HL_enginefuncs_t::fixup_engine_interface( void )
 		pfnQueryClientCvarValue2 = NULL;
 	case 157:
 		pfnEngCheckParm = NULL;
+	case 158:
+		pfnPEntityOfEntIndexAllEntities = NULL;
 	}
 }
 

--- a/metamod/meta_eiface.h
+++ b/metamod/meta_eiface.h
@@ -350,7 +350,8 @@ struct meta_enginefuncs_t : public enginefuncs_t {
 		void             (*_pfnResetTutorMessageDecayData)      (void),
 		void             (*_pfnQueryClientCvarValue)            (const edict_t*, const char*),
 		void             (*_pfnQueryClientCvarValue2)           (const edict_t*, const char*, int),
-		int              (*_pfnEngCheckParm)                    (const char *, char**)
+		int              (*_pfnEngCheckParm)                    (const char *, char**),
+		edict_t*         (*_pfnPEntityOfEntIndexAllEntities)    (int)
         ) DLLINTERNAL;
 
         meta_enginefuncs_t( const meta_enginefuncs_t& ) DLLINTERNAL;
@@ -387,7 +388,8 @@ struct meta_enginefuncs_t : public enginefuncs_t {
 	// 156: includes pfnQueryClientCvarValue()
 	// 157: includes pfnQueryClientCvarValue2()
 	// 158: includes pfnEngCheckParm()
-	static int sm_version DLLHIDDEN;	
+	// 159: includes pfnPEntityOfEntIndexAllEntities()
+	static int sm_version DLLHIDDEN;
 
 };
 

--- a/metamod/tests/test_engine_api.cpp
+++ b/metamod/tests/test_engine_api.cpp
@@ -443,6 +443,7 @@ static int test_hook_all_engine_functions(void)
 	mock_eng_table.pfnQueryClientCvarValue = eng_querycvar;
 	mock_eng_table.pfnQueryClientCvarValue2 = eng_querycvar2;
 	mock_eng_table.pfnEngCheckParm = eng_checkparm;
+	mock_eng_table.pfnPEntityOfEntIndexAllEntities = eng_edict_i;
 
 	edict_t ed;
 	memset(&ed, 0, sizeof(ed));
@@ -613,6 +614,7 @@ static int test_hook_all_engine_functions(void)
 	meta_engfuncs.pfnQueryClientCvarValue(&ed, "c");
 	meta_engfuncs.pfnQueryClientCvarValue2(&ed, "c", 1);
 	meta_engfuncs.pfnEngCheckParm("p", NULL);
+	meta_engfuncs.pfnPEntityOfEntIndexAllEntities(0);
 
 	ASSERT_TRUE(g_eng_call_count > 100);
 
@@ -739,6 +741,21 @@ static int test_engcheckparm_invalid_ptr(void)
 	return 0;
 }
 
+static edict_t *pentity_allents_stub(int) { return NULL; }
+
+static int test_pentityallentities_invalid_ptr(void)
+{
+	TEST("engine hook - PEntityOfEntIndexAllEntities validates invalid pointer");
+	setup_globals();
+	mock_eng_table.pfnPEntityOfEntIndexAllEntities = pentity_allents_stub;
+	g_engfuncs.pfnPEntityOfEntIndexAllEntities = (edict_t *(*)(int))0x4;
+	meta_engfuncs.pfnPEntityOfEntIndexAllEntities(0);
+	ASSERT_TRUE(g_engfuncs.pfnPEntityOfEntIndexAllEntities == NULL);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
 // ============================================================
 // main
 // ============================================================
@@ -755,6 +772,7 @@ int main(void)
 	fail |= test_querycvar_invalid_ptr();
 	fail |= test_querycvar2_invalid_ptr();
 	fail |= test_engcheckparm_invalid_ptr();
+	fail |= test_pentityallentities_invalid_ptr();
 
 	fail |= test_hook_precache_model();
 	fail |= test_hook_precache_sound();

--- a/metamod/tests/test_meta_eiface.cpp
+++ b/metamod/tests/test_meta_eiface.cpp
@@ -64,6 +64,7 @@ static void set_sig_pointers(enginefuncs_t *ef, void *valid_addr)
 	ef->pfnQueryClientCvarValue = (void (*)(const edict_t *, const char *))va;
 	ef->pfnQueryClientCvarValue2 = (void (*)(const edict_t *, const char *, int))va;
 	ef->pfnEngCheckParm = (int (*)(const char *, char **))va;
+	ef->pfnPEntityOfEntIndexAllEntities = (edict_t *(*)(int))va;
 }
 
 // ============================================================
@@ -275,6 +276,7 @@ static int test_hl_engfuncs_init_version_155(void)
 	ef.pfnQueryClientCvarValue = NULL;
 	ef.pfnQueryClientCvarValue2 = NULL;
 	ef.pfnEngCheckParm = NULL;
+	ef.pfnPEntityOfEntIndexAllEntities = NULL;
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
 	ASSERT_INT(meta_enginefuncs_t::version(), 155);
@@ -297,6 +299,7 @@ static int test_hl_engfuncs_init_version_156(void)
 	set_sig_pointers(&ef, fake_engine_sym);
 	ef.pfnQueryClientCvarValue2 = NULL;
 	ef.pfnEngCheckParm = NULL;
+	ef.pfnPEntityOfEntIndexAllEntities = NULL;
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
 	ASSERT_INT(meta_enginefuncs_t::version(), 156);
@@ -318,6 +321,7 @@ static int test_hl_engfuncs_init_version_157(void)
 	memset(&ef, 0, sizeof(ef));
 	set_sig_pointers(&ef, fake_engine_sym);
 	ef.pfnEngCheckParm = NULL;
+	ef.pfnPEntityOfEntIndexAllEntities = NULL;
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
 	ASSERT_INT(meta_enginefuncs_t::version(), 157);
@@ -328,7 +332,28 @@ static int test_hl_engfuncs_init_version_157(void)
 
 static int test_hl_engfuncs_init_version_158(void)
 {
-	TEST("HL_enginefuncs_t::initialise - all valid gives version 158");
+	TEST("HL_enginefuncs_t::initialise - through EngCheckParm gives 158");
+	mock_reset();
+	if (load_fake_engine()) {
+		printf("SKIP\n"); tests_run--; return 0;
+	}
+	Engine.info.initialise(NULL);
+	engfuncs_version_resetter::reset();
+	enginefuncs_t ef;
+	memset(&ef, 0, sizeof(ef));
+	set_sig_pointers(&ef, fake_engine_sym);
+	ef.pfnPEntityOfEntIndexAllEntities = NULL;
+	HL_enginefuncs_t hlef;
+	hlef.initialise_interface(&ef);
+	ASSERT_INT(meta_enginefuncs_t::version(), 158);
+	unload_fake_engine();
+	PASS();
+	return 0;
+}
+
+static int test_hl_engfuncs_init_version_159(void)
+{
+	TEST("HL_enginefuncs_t::initialise - all valid gives version 159");
 	mock_reset();
 	if (load_fake_engine()) {
 		printf("SKIP\n"); tests_run--; return 0;
@@ -340,7 +365,7 @@ static int test_hl_engfuncs_init_version_158(void)
 	set_sig_pointers(&ef, fake_engine_sym);
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
-	ASSERT_INT(meta_enginefuncs_t::version(), 158);
+	ASSERT_INT(meta_enginefuncs_t::version(), 159);
 	unload_fake_engine();
 	PASS();
 	return 0;
@@ -376,6 +401,7 @@ static int test_fixup_version_138(void)
 	ef.pfnSequenceGet = (sequenceEntry_s *(*)(const char *, const char *))0x1;
 	ef.pfnQueryClientCvarValue = (void (*)(const edict_t *, const char *))0x1;
 	ef.pfnEngCheckParm = (int (*)(const char *, char **))0x1;
+	ef.pfnPEntityOfEntIndexAllEntities = (edict_t *(*)(int))0x1;
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
 	ASSERT_INT(meta_enginefuncs_t::version(), 138);
@@ -383,13 +409,14 @@ static int test_fixup_version_138(void)
 	ASSERT_PTR_NULL(hlef.pfnSequenceGet);
 	ASSERT_PTR_NULL(hlef.pfnQueryClientCvarValue);
 	ASSERT_PTR_NULL(hlef.pfnEngCheckParm);
+	ASSERT_PTR_NULL(hlef.pfnPEntityOfEntIndexAllEntities);
 	PASS();
 	return 0;
 }
 
-static int test_fixup_version_158_keeps_ptrs(void)
+static int test_fixup_version_159_keeps_ptrs(void)
 {
-	TEST("fixup - version 158 keeps all sig ptrs");
+	TEST("fixup - version 159 keeps all sig ptrs");
 	mock_reset();
 	if (load_fake_engine()) {
 		printf("SKIP\n"); tests_run--; return 0;
@@ -401,9 +428,10 @@ static int test_fixup_version_158_keeps_ptrs(void)
 	set_sig_pointers(&ef, fake_engine_sym);
 	HL_enginefuncs_t hlef;
 	hlef.initialise_interface(&ef);
-	ASSERT_INT(meta_enginefuncs_t::version(), 158);
+	ASSERT_INT(meta_enginefuncs_t::version(), 159);
 	ASSERT_PTR_NOT_NULL(hlef.pfnGetPlayerAuthId);
 	ASSERT_PTR_NOT_NULL(hlef.pfnEngCheckParm);
+	ASSERT_PTR_NOT_NULL(hlef.pfnPEntityOfEntIndexAllEntities);
 	unload_fake_engine();
 	PASS();
 	return 0;
@@ -480,11 +508,12 @@ int main(void)
 	fail |= test_hl_engfuncs_init_version_156();
 	fail |= test_hl_engfuncs_init_version_157();
 	fail |= test_hl_engfuncs_init_version_158();
+	fail |= test_hl_engfuncs_init_version_159();
 	fail |= test_hl_engfuncs_cached_version();
 
 	// fixup verification
 	fail |= test_fixup_version_138();
-	fail |= test_fixup_version_158_keeps_ptrs();
+	fail |= test_fixup_version_159_keeps_ptrs();
 
 	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 	return fail ? EXIT_FAILURE : EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- Closes #93
- Adds `pfnPEntityOfEntIndexAllEntities` from the HL25 SDK update (2024-08-21) to `enginefuncs_t`
- Wires up full metamod hook dispatch: wrapper with pointer validation, api_info entry, version detection (159), and fixup cascade
- Adds tests for version detection, fixup, and invalid pointer validation

## Test plan
- [x] All existing tests pass
- [x] New version 158 test (nulled `pfnPEntityOfEntIndexAllEntities` only)
- [x] New version 159 test (all valid)
- [x] Fixup version 138 clears the new pointer
- [x] Fixup version 159 keeps all pointers
- [x] Invalid pointer validation test for `PEntityOfEntIndexAllEntities`