### PR TITLE
Fix review comments from PRs #92, #94 and add test coverage

### DIFF
--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -191,7 +191,14 @@ void DLLINTERNAL MPluginList::rebuild_hook_lists(void) {
 		total += ((api_plugin_list_t *)hook_lists)[i].count;
 
 	if(total > 0) {
-		hook_list_data = (MPlugin **)realloc(hook_list_data, total * sizeof(MPlugin *));
+		MPlugin **newdata = (MPlugin **)realloc(hook_list_data, total * sizeof(MPlugin *));
+		if(newdata) {
+			hook_list_data = newdata;
+		} else {
+			META_WARNING("Failed to realloc hook_list_data for %d entries: %s", total, strerror(errno));
+			memset(hook_lists, 0, sizeof(hook_lists));
+			return;
+		}
 	} else {
 		free(hook_list_data);
 		hook_list_data = NULL;

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -118,7 +118,7 @@ test_metamod: test_metamod.o $(EXTENDED_OBJS) $(METAMOD_EXTRA)
 	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 test_mlist: test_mlist.o $(EXTENDED_OBJS) fake_mm_plugin.so
-	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl -Wl,--wrap=realloc
 
 test_mplugin: test_mplugin.o $(EXTENDED_OBJS) mutil.o
 	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl

--- a/metamod/tests/engine_mock.cpp
+++ b/metamod/tests/engine_mock.cpp
@@ -48,6 +48,7 @@ __attribute__((weak)) DLHANDLE metamod_handle = NULL;
 __attribute__((weak)) cvar_t meta_version = {(char *)"metamod_version", (char *)"test", 0, 0, NULL};
 
 __attribute__((weak)) gamedll_t GameDLL;
+__attribute__((weak)) gamedll_funcs_t GameDLL_funcs;
 
 __attribute__((weak)) MConfig *Config = NULL;
 __attribute__((weak)) MPluginList *Plugins = NULL;
@@ -419,6 +420,7 @@ void mock_reset(void)
 	Engine.globals = gpGlobals;
 
 	memset(&GameDLL, 0, sizeof(GameDLL));
+	memset(&GameDLL_funcs, 0, sizeof(GameDLL_funcs));
 
 	metamod_handle = NULL;
 	Config = NULL;

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -937,6 +937,89 @@ static int test_return_post_only_plugin(void)
 }
 
 // ============================================================
+// Tests: nested call with two plugins preserves prev_mres
+// ============================================================
+
+static void plugin1_reentrant_pre_GameInit(void)
+{
+	g_plugin1_pre_called++;
+
+	plugin1_pre_funcs.pfnGameInit = NULL;
+
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnGameInit();
+
+	RETURN_META(MRES_HANDLED);
+}
+
+static int test_nested_two_plugins_prev_mres_preserved(void)
+{
+	TEST("dispatch void - nested call with two plugins preserves prev_mres");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnGameInit = plugin1_reentrant_pre_GameInit;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin2_pre_seen_prev_mres = MRES_UNSET;
+
+	call_hooked_GameInit();
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_plugin2_pre_called == 2);
+	ASSERT_TRUE(g_gamedll_called == 2);
+	// Plugin 2 in outer dispatch should see MRES_HANDLED from plugin 1
+	ASSERT_TRUE(g_plugin2_pre_seen_prev_mres == MRES_HANDLED);
+	teardown();
+	PASS();
+	return 0;
+}
+
+static int g_nested_ret_plugin2_seen_prev_mres;
+
+static int plugin1_reentrant_pre_Spawn(edict_t *ed)
+{
+	g_plugin1_pre_called++;
+
+	plugin1_pre_funcs.pfnSpawn = NULL;
+
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnSpawn(ed);
+
+	RETURN_META_VALUE(MRES_HANDLED, 99);
+}
+
+static int plugin2_pre_Spawn_track_prev(edict_t *)
+{
+	g_plugin2_pre_called++;
+	g_nested_ret_plugin2_seen_prev_mres = gpMetaGlobals->prev_mres;
+	RETURN_META_VALUE(MRES_IGNORED, 0);
+}
+
+static int test_nested_two_plugins_return_prev_mres_preserved(void)
+{
+	TEST("dispatch return - nested call with two plugins preserves prev_mres");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnSpawn = plugin1_reentrant_pre_Spawn;
+	plugin2_pre_funcs.pfnSpawn = plugin2_pre_Spawn_track_prev;
+	g_nested_ret_plugin2_seen_prev_mres = MRES_UNSET;
+
+	int ret = call_hooked_Spawn();
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_plugin2_pre_called == 2);
+	ASSERT_TRUE(g_gamedll_called == 2);
+	// Plugin 2 in outer dispatch should see MRES_HANDLED from plugin 1
+	ASSERT_TRUE(g_nested_ret_plugin2_seen_prev_mres == MRES_HANDLED);
+	ASSERT_TRUE(ret == 42);
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // Tests: void dispatch - post hook MRES_UNSET warning (line 212)
 // ============================================================
 
@@ -1059,12 +1142,14 @@ int main(void)
 
 	// nested call
 	fail |= test_nested_call_restores_globals();
+	fail |= test_nested_two_plugins_prev_mres_preserved();
 
 	// pre MRES_UNSET for return function
 	fail |= test_return_pre_unset_warns();
 
 	// nested return call
 	fail |= test_nested_return_call_restores_globals();
+	fail |= test_nested_two_plugins_return_prev_mres_preserved();
 
 	// post-only plugin
 	fail |= test_void_post_only_plugin();

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -1020,6 +1020,64 @@ static int test_nested_two_plugins_return_prev_mres_preserved(void)
 }
 
 // ============================================================
+// Tests: debug template path produces META_DEBUG messages
+// ============================================================
+
+static int test_debug_dispatch_logs_calls(void)
+{
+	TEST("dispatch void - debug path logs plugin and gamedll calls");
+	setup_one_plugin();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
+	plugin1_post_funcs.pfnGameInit = plugin1_post_GameInit;
+	g_plugin1_pre_mres = MRES_IGNORED;
+	g_plugin1_post_mres = MRES_IGNORED;
+
+	meta_debug_value = 3;
+	call_hooked_GameInit();
+	meta_debug_value = 0;
+
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_gamedll_called == 1);
+	ASSERT_TRUE(g_plugin1_post_called == 1);
+	int found_pre = 0, found_post = 0;
+	for (int i = 0; i < mock_get_alert_count(); i++) {
+		const char *msg = mock_get_alert_msg(i);
+		if (strstr(msg, "Calling plugin1:GameDLLInit()") && !strstr(msg, "Post"))
+			found_pre = 1;
+		if (strstr(msg, "Calling plugin1:GameDLLInit_Post()"))
+			found_post = 1;
+	}
+	ASSERT_TRUE(found_pre);
+	ASSERT_TRUE(found_post);
+	teardown();
+	PASS();
+	return 0;
+}
+
+static int test_no_debug_dispatch_no_logs(void)
+{
+	TEST("dispatch void - non-debug path produces no META_DEBUG messages");
+	setup_one_plugin();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
+	g_plugin1_pre_mres = MRES_IGNORED;
+
+	meta_debug_value = 0;
+	call_hooked_GameInit();
+
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_gamedll_called == 1);
+	int found_calling = 0;
+	for (int i = 0; i < mock_get_alert_count(); i++) {
+		if (strstr(mock_get_alert_msg(i), "Calling"))
+			found_calling = 1;
+	}
+	ASSERT_TRUE(!found_calling);
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // Tests: void dispatch - post hook MRES_UNSET warning (line 212)
 // ============================================================
 
@@ -1139,6 +1197,10 @@ int main(void)
 	// null game DLL (void)
 	fail |= test_null_gamedll_table();
 	fail |= test_null_gamedll_function();
+
+	// debug template path
+	fail |= test_debug_dispatch_logs_calls();
+	fail |= test_no_debug_dispatch_no_logs();
 
 	// nested call
 	fail |= test_nested_call_restores_globals();

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -18,6 +18,16 @@
 #include "engine_mock.h"
 #include "test_common.h"
 
+static bool force_realloc_fail = false;
+
+extern "C" void *__real_realloc(void *ptr, size_t size);
+extern "C" void *__wrap_realloc(void *ptr, size_t size)
+{
+	if (force_realloc_fail)
+		return NULL;
+	return __real_realloc(ptr, size);
+}
+
 static MRegCmdList test_reg_cmds;
 static MRegCvarList test_reg_cvars;
 static MRegMsgList test_reg_msgs;
@@ -4383,6 +4393,45 @@ static int test_rebuild_realloc_shrinks(void)
 	return 0;
 }
 
+static int test_rebuild_realloc_failure_keeps_old(void)
+{
+	TEST("rebuild_hook_lists - realloc failure keeps old lists");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	MPlugin **old_data = list->hook_list_data;
+	ASSERT_PTR_NOT_NULL(old_data);
+
+	// Add a second plugin and force realloc to fail
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+	list->endlist = 2;
+
+	force_realloc_fail = true;
+	list->rebuild_hook_lists();
+	force_realloc_fail = false;
+
+	// Old allocation preserved, but lists zeroed so dispatch is safe
+	ASSERT_PTR_EQ(list->hook_list_data, old_data);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 0);
+	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi)->plugs);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
 static int test_rebuild_to_empty_frees(void)
 {
 	TEST("rebuild_hook_lists - all plugins removed frees allocation");
@@ -4748,6 +4797,7 @@ int main(void)
 	fail |= test_rebuild_two_plugins_order();
 	fail |= test_rebuild_different_api_groups();
 	fail |= test_rebuild_realloc_shrinks();
+	fail |= test_rebuild_realloc_failure_keeps_old();
 	fail |= test_rebuild_to_empty_frees();
 	fail |= test_rebuild_null_tables_ignored();
 	fail |= test_rebuild_plugs_contiguous();


### PR DESCRIPTION
## Summary
- Fix realloc failure handling in `rebuild_hook_lists` — zero `hook_lists` and return early to prevent second pass from writing through NULL plugs pointers; log `META_WARNING` on failure (PR #92 review)
- Clear `GameDLL_funcs` in test `mock_reset` via weak symbol (PR #94 review)
- Add tests for `meta_globals.prev_mres` preservation across re-entrant hook dispatch (PR #87 coverage)
- Add tests for debug/non-debug template dispatch paths using `meta_debug_value` (PR #91 coverage)
- Add realloc failure unit test using `--wrap=realloc` linker flag

## Test plan
- [x] All 137 test_mlist tests pass including new realloc failure test
- [x] All 36 test binaries pass (`make run`)