### PR TITLE
Fix sizeof mismatch in buffered_ALERT vsnprintf

### DIFF
--- a/metamod/log_meta.cpp
+++ b/metamod/log_meta.cpp
@@ -206,7 +206,7 @@ static void buffered_ALERT(MLOG_SERVICE service, ALERT_TYPE atype, const char *p
 	msg->service = service;
 	msg->atype = atype;
 	msg->prefix = prefix;
-	vsnprintf(msg->buf, sizeof(buf), fmt, ap);
+	vsnprintf(msg->buf, sizeof(msg->buf), fmt, ap);
 	msg->next = NULL;
 
 	if (NULL == messageQueueEnd) {


### PR DESCRIPTION
## Summary
- Fix `vsnprintf(msg->buf, sizeof(buf), ...)` to use `sizeof(msg->buf)` instead of the local stack variable's size
- Both are `MAX_LOGMSG_LEN` today so no actual overflow, but using the destination's own size is correct

## Test plan
- [x] Verified both sizes are identical (`MAX_LOGMSG_LEN`) so this is a correctness fix, not a behavioral change