### PR TITLE
Add endbr32 prefix to dlsym hook trampoline

### DIFF
--- a/metamod/osdep_linkent_linux.cpp
+++ b/metamod/osdep_linkent_linux.cpp
@@ -53,8 +53,10 @@
 //  -- by Jussi Kivilinna
 //
 
-//opcode, e9, + sizeof pointer
-#define BYTES_SIZE (1 + sizeof(void*))
+// endbr32 (4 bytes) + jmp rel32 (5 bytes)
+#define ENDBR32_SIZE 4
+#define JMP_INSN_SIZE 5
+#define BYTES_SIZE (ENDBR32_SIZE + JMP_INSN_SIZE)
 
 typedef void * (*dlsym_func)(void * module, const char * funcname);
 
@@ -76,12 +78,16 @@ static pthread_mutex_t mutex_replacement_dlsym = PTHREAD_RECURSIVE_MUTEX_INITIAL
 // Tracks whether original dlsym bytes are currently restored (for re-entrant calls)
 static int is_original_restored = 0;
 
-//constructs new jmp forwarder
+//constructs endbr32 + jmp forwarder
 inline void construct_jmp_instruction(void *x, void *place, void* target)
 {
-	unsigned long rel = (unsigned long)target - ((unsigned long)place + 5);
-	((unsigned char *)x)[0] = 0xe9;
-	memcpy((char *)x + 1, &rel, sizeof(rel));
+	unsigned char *p = (unsigned char *)x;
+	// endbr32: f3 0f 1e fb
+	p[0] = 0xf3; p[1] = 0x0f; p[2] = 0x1e; p[3] = 0xfb;
+	// jmp rel32 (offset relative to end of jmp instruction)
+	p[4] = 0xe9;
+	unsigned long rel = (unsigned long)target - ((unsigned long)place + BYTES_SIZE);
+	memcpy(p + 5, &rel, sizeof(rel));
 }
 
 //checks if pointer x points to jump forwarder

--- a/metamod/tests/test_osdep_linkent_linux.cpp
+++ b/metamod/tests/test_osdep_linkent_linux.cpp
@@ -35,21 +35,27 @@ static void restore_linkent(void)
 
 static int test_construct_jmp_basic(void)
 {
-	TEST("construct_jmp_instruction - produces E9 opcode with correct offset");
-	unsigned char buf[8];
+	TEST("construct_jmp_instruction - endbr32 + jmp with correct offset");
+	unsigned char buf[BYTES_SIZE];
 	memset(buf, 0, sizeof(buf));
 
-	char fake_place[8];
+	char fake_place[16];
 	unsigned long place_addr = (unsigned long)fake_place;
 	unsigned long target_addr = place_addr + 0x1000;
 
 	construct_jmp_instruction(buf, (void *)place_addr, (void *)target_addr);
 
-	ASSERT_TRUE(buf[0] == 0xe9);
+	// endbr32: f3 0f 1e fb
+	ASSERT_TRUE(buf[0] == 0xf3);
+	ASSERT_TRUE(buf[1] == 0x0f);
+	ASSERT_TRUE(buf[2] == 0x1e);
+	ASSERT_TRUE(buf[3] == 0xfb);
+	// jmp opcode
+	ASSERT_TRUE(buf[4] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
-	unsigned long expected_offset = target_addr - (place_addr + 5);
+	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	unsigned long expected_offset = target_addr - (place_addr + BYTES_SIZE);
 	ASSERT_TRUE(encoded_offset == expected_offset);
 
 	PASS();
@@ -59,20 +65,22 @@ static int test_construct_jmp_basic(void)
 static int test_construct_jmp_backward(void)
 {
 	TEST("construct_jmp_instruction - backward jump has negative offset");
-	unsigned char buf[8];
+	unsigned char buf[BYTES_SIZE];
 	memset(buf, 0, sizeof(buf));
 
-	char fake_place[8];
+	char fake_place[16];
 	unsigned long place_addr = (unsigned long)fake_place;
 	unsigned long target_addr = place_addr - 0x100;
 
 	construct_jmp_instruction(buf, (void *)place_addr, (void *)target_addr);
 
-	ASSERT_TRUE(buf[0] == 0xe9);
+	ASSERT_TRUE(buf[0] == 0xf3);
+	ASSERT_TRUE(buf[3] == 0xfb);
+	ASSERT_TRUE(buf[4] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
-	unsigned long expected_offset = target_addr - (place_addr + 5);
+	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	unsigned long expected_offset = target_addr - (place_addr + BYTES_SIZE);
 	ASSERT_TRUE(encoded_offset == expected_offset);
 
 	PASS();
@@ -81,18 +89,19 @@ static int test_construct_jmp_backward(void)
 
 static int test_construct_jmp_self(void)
 {
-	TEST("construct_jmp_instruction - jump to self (offset = -5)");
-	unsigned char buf[8];
+	TEST("construct_jmp_instruction - jump to self (offset = -BYTES_SIZE)");
+	unsigned char buf[BYTES_SIZE];
 	memset(buf, 0, sizeof(buf));
 
-	char fake_place[8];
+	char fake_place[16];
 	construct_jmp_instruction(buf, fake_place, fake_place);
 
-	ASSERT_TRUE(buf[0] == 0xe9);
+	ASSERT_TRUE(buf[0] == 0xf3);
+	ASSERT_TRUE(buf[4] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
-	ASSERT_TRUE(encoded_offset == (unsigned long)-5);
+	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	ASSERT_TRUE(encoded_offset == (unsigned long)-(long)BYTES_SIZE);
 
 	PASS();
 	return 0;


### PR DESCRIPTION
## Summary
- Prepend `endbr32` (f3 0f 1e fb) to the `jmp rel32` trampoline written over `dlsym`, expanding from 5 to 9 bytes
- Required for CET/IBT (Control-flow Enforcement Technology) on modern x86 kernels where indirect call targets must begin with `endbr32`

## Test plan
- [x] `test_osdep_linkent_linux` updated and passes (12/12)
- [x] Full test suite passes (36/36 binaries)