### PR TITLE
Update version defaults and URLs for GitHub migration

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -3,7 +3,7 @@
 Current version: 1.20p35
 
 For newer changes, see Metamod-P git repository commit log at:
- http://metamod-p.git.sourceforge.net/git/gitweb.cgi?p=metamod-p/metamod-p;a=summary
+ https://github.com/Bots-United/metamod-p
 
 ---
 

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -184,6 +184,10 @@ CFLAGS+=-std=gnu++98 -Wno-c++11-compat
 ifdef META_VERSION
 META_DEFS += -DVPATCH_IVERSION=$(META_VERSION) -DVPATCH_VERSION="\"$(META_VERSION)\""
 META_DEFS_RES += '-DVPATCH_IVERSION=$(META_VERSION)' '-DVPATCH_VERSION="\"$(META_VERSION)\""'
+else
+META_GIT_VERSION := 0git$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+META_DEFS += -DVPATCH_VERSION="\"$(META_GIT_VERSION)\""
+META_DEFS_RES += '-DVPATCH_VERSION="\"$(META_GIT_VERSION)\""'
 endif
 ifdef META_DATE
 META_COPYRIGHT_YEAR := $(firstword $(subst /, ,$(META_DATE)))

--- a/metamod/commands_meta.cpp
+++ b/metamod/commands_meta.cpp
@@ -193,19 +193,34 @@ void DLLINTERNAL client_meta_aybabtu(edict_t *pEntity) {
 	META_CLIENT(pEntity, "%s", "All Your Base Are Belong To Us");
 }
 
+static edict_t *client_print_entity;
+
+static void DLLINTERNAL_NOVIS client_print_wrapper(const char *fmt, ...) {
+	va_list ap;
+	char buf[1024];
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+	META_CLIENT(client_print_entity, "%s", buf);
+}
+
+void DLLINTERNAL print_version(meta_print_func_t print) {
+	print("%s v%s  %s (%s)", VNAME, VVERSION, VDATE, META_INTERFACE_VERSION);
+	print("by %s", VAUTHOR);
+	print("   %s", VURL);
+	print(" Patch: %s v%s", VPATCH_NAME, VPATCH_VERSION);
+	print(" by %s", VPATCH_AUTHOR);
+	print("    %s", VPATCH_WEBSITE);
+	print("compiled: %s %s (%s)", COMPILE_TIME, COMPILE_TZONE, OPT_TYPE);
+}
+
 // "meta version" console command.
 void DLLINTERNAL cmd_meta_version(void) {
 	if(CMD_ARGC() != 2) {
 		META_CONS("usage: meta version");
 		return;
 	}
-	META_CONS("%s v%s  %s (%s)", VNAME, VVERSION, VDATE, META_INTERFACE_VERSION);
-	META_CONS("by %s", VAUTHOR);
-	META_CONS("   %s", VURL);
-	META_CONS(" Patch: %s v%d", VPATCH_NAME, VPATCH_IVERSION);
-	META_CONS(" by %s", VPATCH_AUTHOR);
-	META_CONS("    %s", VPATCH_WEBSITE);
-	META_CONS("compiled: %s %s (%s)", COMPILE_TIME, COMPILE_TZONE, OPT_TYPE);
+	print_version(META_CONS);
 }
 
 // "meta version" client command.
@@ -214,13 +229,8 @@ void DLLINTERNAL client_meta_version(edict_t *pEntity) {
 		META_CLIENT(pEntity, "usage: meta version");
 		return;
 	}
-	META_CLIENT(pEntity, "%s v%s  %s (%s)", VNAME, VVERSION, VDATE, META_INTERFACE_VERSION);
-	META_CLIENT(pEntity, "by %s", VAUTHOR);
-	META_CLIENT(pEntity, "   %s", VURL);
-	META_CLIENT(pEntity, " Patch: %s v%d", VPATCH_NAME, VPATCH_IVERSION);
-	META_CLIENT(pEntity, " by %s", VPATCH_AUTHOR);
-	META_CLIENT(pEntity, "    %s", VPATCH_WEBSITE);
-	META_CLIENT(pEntity, "compiled: %s %s (%s)", COMPILE_TIME, COMPILE_TZONE, OPT_TYPE);
+	client_print_entity = pEntity;
+	print_version(client_print_wrapper);
 	META_CLIENT(pEntity, "ifvers: %s", META_INTERFACE_VERSION);
 }
 

--- a/metamod/commands_meta.h
+++ b/metamod/commands_meta.h
@@ -59,6 +59,9 @@ void DLLINTERNAL meta_register_cmdcvar();
 
 void DLLHIDDEN svr_meta(void); // only hidden because called from outside!
 
+typedef void (DLLINTERNAL_NOVIS *meta_print_func_t)(const char *fmt, ...);
+void DLLINTERNAL print_version(meta_print_func_t print);
+
 void DLLINTERNAL cmd_meta_usage(void);
 void DLLINTERNAL cmd_meta_version(void);
 void DLLINTERNAL cmd_meta_gpl(void);

--- a/metamod/metamod.cpp
+++ b/metamod/metamod.cpp
@@ -98,19 +98,13 @@ int DLLINTERNAL metamod_startup(void) {
 
 	META_CONS("   ");
 	META_CONS("   %s version %s Copyright (c) 2001-%s %s", VNAME, VVERSION, COPYRIGHT_YEAR, VAUTHOR);
-	META_CONS("     Patch: %s v%d Copyright (c) 2004-%s %s", VPATCH_NAME, VPATCH_IVERSION, VPATCH_COPYRIGHT_YEAR, VPATCH_AUTHOR);
+	META_CONS("     Patch: %s v%s Copyright (c) 2004-%s %s", VPATCH_NAME, VPATCH_VERSION, VPATCH_COPYRIGHT_YEAR, VPATCH_AUTHOR);
 	META_CONS("   %s comes with ABSOLUTELY NO WARRANTY; for details type `meta gpl'.", VNAME);
 	META_CONS("   This is free software, and you are welcome to redistribute it");
 	META_CONS("   under certain conditions; type `meta gpl' for details.");
 	META_CONS("   ");
 
-	META_LOG("%s v%s  %s", VNAME, VVERSION, VDATE);
-	META_LOG("by %s", VAUTHOR);
-	META_LOG("   %s", VURL);
-	META_LOG(" Patch: %s v%d", VPATCH_NAME, VPATCH_IVERSION);
-	META_LOG(" by %s", VPATCH_AUTHOR);
-	META_LOG("    %s", VPATCH_WEBSITE);
-	META_LOG("compiled: %s %s (%s)", COMPILE_TIME, COMPILE_TZONE, OPT_TYPE);
+	print_version(META_LOG);
 
 	// If running with "+developer", allow an opportunity to break in with
 	// a debugger.

--- a/metamod/tests/test_metamod_gamedll.cpp
+++ b/metamod/tests/test_metamod_gamedll.cpp
@@ -167,8 +167,12 @@ int DLLINTERNAL init_linkent_replacement(DLHANDLE, DLHANDLE)
 	return g_init_linkent_return ? 1 : 0;
 }
 
-// meta_register_cmdcvar is in commands_meta.cpp
+// Stubs for commands_meta.cpp functions
 void DLLINTERNAL meta_register_cmdcvar()
+{
+}
+
+void DLLINTERNAL print_version(meta_print_func_t)
 {
 }
 

--- a/metamod/vdate.cpp
+++ b/metamod/vdate.cpp
@@ -48,7 +48,7 @@
 char const *COMPILE_TIME=__DATE__ ", " __TIME__;
 
 #ifndef COMPILE_TZ
-	#define COMPILE_TZ "EET"
+	#define COMPILE_TZ "UTC"
 #endif
 
 char const *COMPILE_TZONE = COMPILE_TZ;

--- a/metamod/vers_meta.h
+++ b/metamod/vers_meta.h
@@ -44,22 +44,22 @@
 
 
 #ifndef VDATE
-#define VDATE 			"2018/02/11"
+#define VDATE 			"yyyy/mm/dd"
 #endif
 #ifndef VPATCH_COPYRIGHT_YEAR
-#define VPATCH_COPYRIGHT_YEAR   "2018"
+#define VPATCH_COPYRIGHT_YEAR   "yyyy"
 #endif
 #define VMETA_VERSION		"1.21"
 
 #define VPATCH_NAME		"Metamod-P (mm-p)"
 #ifndef VPATCH_IVERSION
-#define VPATCH_IVERSION		38
+#define VPATCH_IVERSION		0
 #endif
 #ifndef VPATCH_VERSION
-#define VPATCH_VERSION		"38"
+#define VPATCH_VERSION		"0"
 #endif
 #define VPATCH_AUTHOR		"Jussi Kivilinna"
-#define VPATCH_WEBSITE		"http://metamod-p.sourceforge.net/"
+#define VPATCH_WEBSITE		"https://github.com/Bots-United/metamod-p"
 
 #define VVERSION		VMETA_VERSION "p" VPATCH_VERSION
 #define RC_VERS_DWORD		1,21,0,VPATCH_IVERSION	// Version Windows DLL Resources in res_meta.rc


### PR DESCRIPTION
## Summary
- Replace sourceforge URLs with GitHub in Changelog and vers_meta.h
- Reset version/date defaults to placeholders (filled at build time via `META_DATE`/`META_VERSION` make variables from release tags)
- Default `VPATCH_VERSION` to `"0git<short-hash>"` when `META_VERSION` is not set, producing version strings like `1.21p0gitXXXXXXX` in dev builds
- Change default compile timezone from EET to UTC
- Unify version output into shared `print_version()` function, eliminating three duplicate copies (console command, client command, startup log)
- Switch "Patch:" display line from integer `VPATCH_IVERSION` to string `VPATCH_VERSION`

## Test plan
- [x] Linux debug and optimized builds clean
- [x] Win32 cross-compile build clean
- [x] `META_VERSION=42` override verified (produces `1.21p42`)
- [x] Full test suite passes (36 binaries)