### PR TITLE
Fix missing PE exports in mingw Win32 build

### DIFF
--- a/metamod/osdep.h
+++ b/metamod/osdep.h
@@ -80,11 +80,7 @@
 // DLL.
 #undef DLLEXPORT
 #ifdef _WIN32
-	#if defined(_MSC_VER)
 	#define DLLEXPORT	__declspec(dllexport)
-	#elif defined(__GNUC__)
-	#define DLLEXPORT	__attribute__ ((externally_visible))
-	#endif
 	// WINAPI should be provided in the windows compiler headers.
 	// It's usually defined to something like "__stdcall".
 #elif defined(__linux__)


### PR DESCRIPTION
## Summary

- The `_WIN32 + __GNUC__` (mingw) code path in `osdep.h` used `__attribute__((externally_visible))` for `DLLEXPORT`, which does not add symbols to the PE export table
- The engine's `GetProcAddress("GiveFnptrsToDll")` returned NULL, causing a crash at address `0x00000000` on startup
- Use `__declspec(dllexport)` for all Win32 compilers, matching what mingw-built metamod plugins (e.g. jk_botti) already do

## Test plan

- [x] Win32 cross-compile builds cleanly
- [x] Verified `GiveFnptrsToDll` and other entry points present in PE export table via `objdump`
- [x] Tested on HL:Arena listenserver (BugfixedHL) — metamod loads and runs correctly

Fixes #103