### PR TITLE
Fix build date timezone to use UTC instead of EET

### DIFF
--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -59,11 +59,7 @@ DLLS_DIR=../dlls
 SDKSRC=../hlsdk
 METADIR=../metamod
 
-COMPILE_TZ=EET
-## Developer overrides
-ifeq "$(USER)" "jussi"
-	COMPILE_TZ=EET
-endif
+COMPILE_TZ=UTC
 
 
 #############################################################################


### PR DESCRIPTION
## Summary
- Change `COMPILE_TZ` from hardcoded `EET` to `UTC` for locale-neutral build timestamps
- Remove developer-specific override block that also set EET

## Test plan
- [ ] Build and verify `meta version` shows UTC timezone