### PR TITLE
Two fixes, and build the tests the way the release is built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -21,6 +21,20 @@ jobs:
         run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run
       - name: Run valgrind
         run: CXX="i686-linux-gnu-g++" make -C metamod/tests valgrind
+      - name: Run tests optimized
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run-opt
+
+  test-release-flags:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 valgrind
+      - name: Run tests built with release flags
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run-release
 
   sanitize:
     runs-on: ubuntu-24.04
@@ -36,7 +50,7 @@ jobs:
 
   clang-sanitize:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -47,6 +61,8 @@ jobs:
         run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests run
       - name: Run tests with clang ASan and UBSan
         run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests clang-sanitize
+      - name: Run tests with clang optimized
+        run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests run-opt
 
   coverage:
     runs-on: ubuntu-24.04
@@ -85,7 +101,7 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, sanitize, clang-sanitize, coverage, build]
+    needs: [test, test-release-flags, sanitize, clang-sanitize, coverage, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/metamod/game_autodetect.cpp
+++ b/metamod/game_autodetect.cpp
@@ -45,8 +45,10 @@
 const char * DLLINTERNAL autodetect_gamedll(const gamedll_t *gamedll, const char *knownfn)
 {
 	static char buf[256];
-	char dllpath[256];
-	char fnpath[256];
+	// full_gamedir_path resolves through realpath, which writes up to
+	// PATH_MAX regardless of what the caller has room for.
+	char dllpath[PATH_MAX];
+	char fnpath[PATH_MAX];
 	DIR *dir;
 	struct dirent *ent;
 	unsigned int fn_len;

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -95,7 +95,9 @@ class MPluginList : public class_metamod_new {
 
 	// constructor/destructor:
 		MPluginList(const char *ifile) DLLINTERNAL;
-		~MPluginList(void) DLLINTERNAL;
+		// Not DLLINTERNAL: __cxa_atexit calls a static object's destructor
+		// as plain cdecl, where regparm would look for `this` in a register.
+		~MPluginList(void);
 
 	// functions:
 		void DLLINTERNAL reset_plugin(MPlugin *pl_find);

--- a/metamod/mplayer.h
+++ b/metamod/mplayer.h
@@ -63,7 +63,9 @@ public:
 
 public:
 	MPlayer() DLLINTERNAL;
-	~MPlayer() DLLINTERNAL;
+	// Not DLLINTERNAL, for the reason on ~MPluginList: regparm cannot
+	// survive a destructor reached through __cxa_atexit.
+	~MPlayer();
 	void        DLLINTERNAL set_cvar_query(const char *cvar);            // mark this player as querying a client cvar
 	void        DLLINTERNAL clear_cvar_query(const char *cvar=NULL);     // unmark this player as querying a client cvar
 	const char *DLLINTERNAL is_querying_cvar(void);                      // check if a player is querying a cvar. returns

--- a/metamod/tests/.gitignore
+++ b/metamod/tests/.gitignore
@@ -24,6 +24,7 @@ test_api_info
 test_commands_meta
 test_dllapi
 test_engine_api
+bench_api_hook
 test_h_export
 test_linkgame
 test_linkplug

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -193,7 +193,7 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_metamod_gamedll \
     test_osdep_detect_gamedll_win32 test_osdep_linkent_win32
 
-.PHONY: all run run-opt run-release valgrind sanitize clang-sanitize coverage coverage-clean clean
+.PHONY: all run run-opt run-release bench valgrind sanitize clang-sanitize coverage coverage-clean clean
 
 all: $(ALL_TESTS)
 
@@ -217,6 +217,20 @@ RELEASE_FLAGS = -O2 -fomit-frame-pointer -flto=auto -fPIC -fvisibility=hidden \
 run-release:
 	$(MAKE) clean
 	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" run
+
+# Dispatch cost of the API wrappers, with trivial plugin and gamedll callees
+# so what is measured is metamod's own overhead. A live server buries that
+# under the ~97% of cycles it spends elsewhere, which is enough to hide a
+# regression: pin it to a core and compare against a build of the base branch.
+# Built the way metamod.so is: measuring -O0 code would say nothing.
+bench:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" bench_api_hook
+	taskset -c 8 ./bench_api_hook
+
+bench_api_hook: bench_api_hook.o $(EXTENDED_OBJS) api_hook.o api_info.o \
+    dllapi.o engine_api.o commands_meta.o vdate.o mutil.o
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -193,12 +193,30 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_metamod_gamedll \
     test_osdep_detect_gamedll_win32 test_osdep_linkent_win32
 
-.PHONY: all run valgrind sanitize clang-sanitize coverage coverage-clean clean
+.PHONY: all run run-opt run-release valgrind sanitize clang-sanitize coverage coverage-clean clean
 
 all: $(ALL_TESTS)
 
 run: $(ALL_TESTS)
 	@for t in $(ALL_TESTS); do ./$$t || exit 1; done
+
+# The shipped build is optimized. Argument marshalling that folds away only
+# once the optimizer can see through a copy is invisible at the default -O0,
+# so the suite is also worth running the way the release is built.
+run-opt:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="-O2" run
+
+# metamod.so is built with different code generation and a different calling
+# convention than the tests default to: PIC, regparm, no frame pointer. Which
+# prologue a wrapper gets, and where its arguments live, follow from those, so
+# argument marshalling can be right in one build and wrong in the other.
+RELEASE_FLAGS = -O2 -fomit-frame-pointer -flto=auto -fPIC -fvisibility=hidden \
+    -mtune=generic -fno-exceptions -fno-rtti -D__INTERNALS_USE_REGPARAMS__
+
+run-release:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" run
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 

--- a/metamod/tests/bench_api_hook.cpp
+++ b/metamod/tests/bench_api_hook.cpp
@@ -1,0 +1,192 @@
+//
+// metamod-p - dispatch cost microbenchmark
+//
+// Drives real API wrappers in a fixed-iteration loop: wrapper ->
+// main_hook_function -> one hooked plugin -> gamedll/engine, with trivial
+// callees so what is left is metamod's own dispatch and argument
+// marshalling. A live server buries that under ~97% unrelated cycles.
+//
+// Reports TSC ticks per call, minimum of several repetitions so an
+// interrupt lands in the discarded runs rather than the reported one.
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stddef.h>
+
+#include <extdll.h>
+
+#include "metamod.h"
+#include "dllapi.h"
+#include "engine_api.h"
+#include "api_info.h"
+#include "api_hook.h"
+#include "meta_api.h"
+#include "meta_eiface.h"
+#include "mlist.h"
+#include "mreg.h"
+#include "mplugin.h"
+#include "conf_meta.h"
+
+#include "engine_mock.h"
+
+meta_globals_t *gpMetaGlobals = &PublicMetaGlobals;
+
+static MPluginList &bench_plugins = *new MPluginList("plugins.ini");
+static MRegCmdList bench_cmds;
+static MRegCvarList bench_cvars;
+static MRegMsgList bench_msgs;
+static MConfig bench_config;
+static option_t bench_options[] = { { NULL, CF_NONE, NULL, NULL } };
+
+static DLL_FUNCTIONS gamedll_table;
+static DLL_FUNCTIONS plugin_pre_table;
+static enginefuncs_t engine_table;
+static enginefuncs_t *engine_table_ptr = &engine_table;
+
+// ---------------------------------------------------------------
+// Callees. Empty, but not inlinable: what is being timed is the cost of
+// reaching them, and each must set meta_result or dispatch warns.
+// ---------------------------------------------------------------
+
+static NOINLINE void plug_void_p(edict_t *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_2p(edict_t *, edict_t *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_p2i(edict_t *, int, int) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_4pi(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int)
+	{ PublicMetaGlobals.mres = MRES_IGNORED; }
+
+static NOINLINE void dll_void_p(edict_t *) {}
+static NOINLINE void dll_void_2p(edict_t *, edict_t *) {}
+static NOINLINE void dll_void_p2i(edict_t *, int, int) {}
+static NOINLINE void dll_void_4pi(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int) {}
+
+static NOINLINE void eng_runplayermove(edict_t *, const float *, float, float, float,
+				       unsigned short, byte, byte) {}
+static NOINLINE void eng_playbackevent(int, const edict_t *, unsigned short, float, float *,
+				       float *, float, float, int, int, int, int) {}
+static NOINLINE void eng_setmodel(edict_t *, const char *) {}
+
+// ---------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------
+
+static inline unsigned long long rdtsc_now(void)
+{
+	unsigned int lo, hi;
+	__asm__ __volatile__ ("lfence\n\trdtsc" : "=a"(lo), "=d"(hi) :: "memory");
+	return ((unsigned long long)hi << 32) | lo;
+}
+
+#define ITERS 200000
+#define REPS  15
+
+// Each case is a block that calls the wrapper ITERS times; the wrapper is
+// reached through a volatile pointer so the call cannot be devirtualized
+// or hoisted.
+#define BENCH(name, decl_fn, setup, call) do { \
+	double best = 0; \
+	for (int rep = 0; rep < REPS; rep++) { \
+		setup; \
+		unsigned long long t0 = rdtsc_now(); \
+		for (int i = 0; i < ITERS; i++) { call; } \
+		unsigned long long t1 = rdtsc_now(); \
+		double per = (double)(t1 - t0) / ITERS; \
+		if (rep == 0 || per < best) best = per; \
+	} \
+	printf("%-28s %8.1f\n", name, best); \
+} while (0)
+
+static void setup_globals(void)
+{
+	mock_reset();
+	Plugins = &bench_plugins;
+	RegCmds = &bench_cmds;
+	RegCvars = &bench_cvars;
+	RegMsgs = &bench_msgs;
+	memset(&bench_config, 0, sizeof(bench_config));
+	bench_config.init(bench_options);
+	Config = &bench_config;
+	metamod_not_loaded = 0;
+
+	memset(&gamedll_table, 0, sizeof(gamedll_table));
+	gamedll_table.pfnThink = dll_void_p;
+	gamedll_table.pfnUse = dll_void_2p;
+	gamedll_table.pfnServerActivate = dll_void_p2i;
+	gamedll_table.pfnSaveWriteFields = dll_void_4pi;
+	GameDLL_funcs.dllapi_table = &gamedll_table;
+
+	memset(&engine_table, 0, sizeof(engine_table));
+	engine_table.pfnRunPlayerMove = eng_runplayermove;
+	engine_table.pfnPlaybackEvent = eng_playbackevent;
+	engine_table.pfnSetModel = eng_setmodel;
+	Engine_funcs = engine_table_ptr;
+
+	// One plugin hooking the same functions, so each dispatch walks a
+	// non-empty hook list the way a real server does.
+	memset(&plugin_pre_table, 0, sizeof(plugin_pre_table));
+	plugin_pre_table.pfnThink = plug_void_p;
+	plugin_pre_table.pfnUse = plug_void_2p;
+	plugin_pre_table.pfnServerActivate = plug_void_p2i;
+	plugin_pre_table.pfnSaveWriteFields = plug_void_4pi;
+
+	free(bench_plugins.hook_list_data);
+	memset(&bench_plugins, 0, sizeof(bench_plugins));
+	MPlugin *plug = &bench_plugins.plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->index = 1;
+	snprintf(plug->filename, sizeof(plug->filename), "bench_plugin");
+	plug->file = plug->filename;
+	plug->tables.dllapi = &plugin_pre_table;
+	bench_plugins.endlist = 1;
+	bench_plugins.rebuild_hook_lists();
+}
+
+int main(void)
+{
+	DLL_FUNCTIONS dll;
+	int version = INTERFACE_VERSION;
+	edict_t ed;
+	float vec[3] = { 1.0f, 2.0f, 3.0f };
+	SAVERESTOREDATA srd;
+	TYPEDESCRIPTION td;
+
+	memset(&ed, 0, sizeof(ed));
+	memset(&srd, 0, sizeof(srd));
+	memset(&td, 0, sizeof(td));
+
+	setup_globals();
+	meta_new_dll_functions_t::test_set_version(3);
+	memset(&dll, 0, sizeof(dll));
+	if (!GetEntityAPI2(&dll, &version)) {
+		printf("GetEntityAPI2 failed\n");
+		return 1;
+	}
+
+	printf("%-28s %8s   (%d iters, best of %d)\n", "wrapper (pack, args)", "ticks", ITERS, REPS);
+	printf("---------------------------------------------\n");
+
+	void (* volatile think)(edict_t *) = dll.pfnThink;
+	void (* volatile use)(edict_t *, edict_t *) = dll.pfnUse;
+	void (* volatile activate)(edict_t *, int, int) = dll.pfnServerActivate;
+	void (* volatile savefields)(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int)
+		= dll.pfnSaveWriteFields;
+	void (* volatile setmodel)(edict_t *, const char *) = meta_engfuncs.pfnSetModel;
+	void (* volatile runmove)(edict_t *, const float *, float, float, float, unsigned short, byte, byte)
+		= meta_engfuncs.pfnRunPlayerMove;
+	void (* volatile playback)(int, const edict_t *, unsigned short, float, float *, float *,
+				   float, float, int, int, int, int) = meta_engfuncs.pfnPlaybackEvent;
+
+	BENCH("dllapi Think (p, 1)",        , (void)0, think(&ed));
+	BENCH("dllapi Use (2p, 2)",         , (void)0, use(&ed, &ed));
+	BENCH("dllapi ServerActivate (p2i, 3)", , (void)0, activate(&ed, 32, 16));
+	BENCH("dllapi SaveWriteFields (4pi, 5)", , (void)0, savefields(&srd, "n", &srd, &td, 1));
+	BENCH("engine SetModel (2p, 2)",    , (void)0, setmodel(&ed, "m"));
+	BENCH("engine RunPlayerMove (2p3fus2uc, 8)", , (void)0,
+	      runmove(&ed, vec, 1.0f, 2.0f, 3.0f, (unsigned short)0x1234, (byte)7, (byte)13));
+	BENCH("engine PlaybackEvent (ipusf2p2f4i, 12)", , (void)0,
+	      playback(1, &ed, (unsigned short)0x5678, 0.5f, vec, vec, 1.5f, 2.5f, 3, 4, 5, 6));
+
+	return 0;
+}

--- a/metamod/tests/stubs.cpp
+++ b/metamod/tests/stubs.cpp
@@ -19,14 +19,20 @@ extern __attribute__((weak)) const engine_info_t engine_info = {};
 __attribute__((weak)) gamedll_funcs_t GameDLL_funcs = {};
 __attribute__((weak)) mutil_funcs_t MetaUtilFunctions = {};
 __attribute__((weak)) enginefuncs_t *Engine_funcs = NULL;
-__attribute__((weak)) meta_enginefuncs_t meta_engfuncs;
+// Storage only, under the real symbol name, for tests that do not link
+// engine_api.o. A weak object of the real type would run its default
+// constructor even where engine_api.o's strong definition wins, and which
+// of the two runs last is unspecified: with LTO it was the default one,
+// which zeroed the table engine_api.o had just filled.
+__attribute__((weak, aligned(16)))
+char meta_engfuncs_stub_storage[sizeof(meta_enginefuncs_t)] __asm__("meta_engfuncs");
 
-__attribute__((weak)) void main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *) {}
-__attribute__((weak)) void *main_hook_function(const class_ret_t, unsigned int, enum_api_t, unsigned int, const void *) { return NULL; }
+__attribute__((weak)) void DLLINTERNAL main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *) {}
+__attribute__((weak)) void * DLLINTERNAL main_hook_function(const class_ret_t, unsigned int, enum_api_t, unsigned int, const void *) { return NULL; }
 
-__attribute__((weak)) void client_meta(edict_t *) {}
+__attribute__((weak)) void DLLINTERNAL client_meta(edict_t *) {}
 
-__attribute__((weak)) const char *META_UTIL_VarArgs(const char *, ...)
+__attribute__((weak)) const char * DLLINTERNAL META_UTIL_VarArgs(const char *, ...)
 {
 	static char buf[] = "";
 	return buf;

--- a/metamod/tests/test_game_support.cpp
+++ b/metamod/tests/test_game_support.cpp
@@ -20,7 +20,7 @@
 #include "test_common.h"
 
 // install_gamedll is DLLINTERNAL, declare it for testing
-extern mBOOL install_gamedll(char *from, const char *to);
+extern mBOOL DLLINTERNAL install_gamedll(char *from, const char *to);
 
 // ============================================================
 // Temp directory helpers


### PR DESCRIPTION
Split out of #112, which is where the argument marshalling changes live. Nothing here depends on those.

## Fixes

`autodetect_gamedll` passed 256-byte stack buffers to `full_gamedir_path`, which resolves through `realpath` and writes up to `PATH_MAX` whatever the caller has room for. A gamedir deep enough to resolve past 256 bytes overran them. The other four call sites already pass `PATH_MAX` buffers.

`~MPluginList` and `~MPlayer` were `DLLINTERNAL`, so regparm in optimized builds, but a static object's destructor is registered with `__cxa_atexit` and called as plain cdecl, leaving `this` in a register nobody reads. regparm buys nothing on a destructor and `-fvisibility=hidden` keeps both unexported without it.

## Building the tests like the release

`metamod.so` is built PIC, with regparm, without a frame pointer, and optimized; the tests used none of that. Code generation and calling convention follow from those, so a bug can be absent in one build and present in the other. `make run-opt` builds the suite at `-O2`, `make run-release` builds it the way `metamod.so` is built including `-flto=auto`, and CI runs both.

That took two test fixes: `test_game_support` declared `install_gamedll` without the `DLLINTERNAL` its own comment mentions, so it called a regparm function through cdecl, and the stub definitions likewise dropped the attribute their declarations carry. `stubs.cpp`'s weak `meta_engfuncs`, being an object of the real type, also ran its default constructor even where `engine_api.o`'s strong definition won, and which of the two runs last is unspecified -- with LTO it was the default one, which zeroed the table `engine_api.o` had just filled. Making it raw storage under the same symbol leaves nothing to run. `metamod.so` was never affected, having only the one definition.

The first of these fixes was found by the LTO build: `_FORTIFY_SOURCE` can see the real destination size once inlining opens it up, and `__realpath_chk` aborts.

## Dispatch benchmark

`make -C metamod/tests bench` drives the real wrappers in a fixed-iteration loop with trivial plugin and gamedll callees, so what is timed is metamod's own dispatch and marshalling. On a live server that is ~3% of cycles under bot load that varies more between runs than most changes to it, so neither perf sampling nor META_PERFMON resolves anything at that scale. It is built the way `metamod.so` is, pinned to a core, and reported as the best of several repetitions.

It has already earned its place: it measured a 20-25% regression in a marshalling change that looked like a win on instruction count, which is why that change is no longer in #112.

## Testing

851/851 with gcc at `-O0`, `-O2` and release flags, and with clang at `-O0`. Clean gcc and win32 builds, no warnings. `.text` moves 165342 -> 165338, the four bytes being the widened path buffers.